### PR TITLE
docs: add README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@
 Canister smart contracts on the Internet Computer consume compute and memory resources.
 Given that resources are finite, there are bounds in place when canisters execute a message (transaction):
 
-1. __Instructions__: This a monotonically increasing counter that's corelated with the amount of computation and memory accesses.
-2. __Dirty Pages__: The number of memory pages that are written to.
+1. __Instructions__: a monotonically increasing counter that's corelated with the amount of computation and memory accesses.
+2. __Dirty Pages__: the number of memory pages that are written to.
 
 A single message execution must stay within the allowed bounds, otherwise it's terminated.
 `canbench` provides developers the tools and insights to understand how their code is using these resources.


### PR DESCRIPTION
Adds a basic README that will be improved on in the future.

Note: we're still using the term `canbench`. The renaming will be done in one go in a future step.