### PR TITLE
chore: address prodsec issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,7 +204,6 @@ dependencies = [
  "serde",
  "serde_yaml",
  "sha256",
- "tempdir",
  "tempfile",
  "wasmparser",
 ]
@@ -476,12 +475,6 @@ checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
-
-[[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "futures-channel"
@@ -1007,58 +1000,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
-]
-
-[[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
 ]
 
 [[package]]
@@ -1364,16 +1311,6 @@ checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
 dependencies = [
  "core-foundation-sys",
  "libc",
-]
-
-[[package]]
-name = "tempdir"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
-dependencies = [
- "rand",
- "remove_dir_all",
 ]
 
 [[package]]

--- a/canbench-bin/Cargo.toml
+++ b/canbench-bin/Cargo.toml
@@ -2,6 +2,7 @@
 name = "canbench-bin"
 version = "0.1.0"
 edition = "2021"
+license = "Apache-2.0"
 
 [[bin]]
 name = "canbench"
@@ -24,4 +25,3 @@ wasmparser.workspace = true
 
 [dev-dependencies]
 pretty_assertions = "1.4.0"
-tempdir = "0.3.7"

--- a/canbench-bin/tests/utils.rs
+++ b/canbench-bin/tests/utils.rs
@@ -5,7 +5,7 @@ use std::{
     path::PathBuf,
     process::{Command, Output},
 };
-use tempdir::TempDir;
+use tempfile::tempdir;
 
 #[macro_export]
 macro_rules! assert_err {
@@ -71,7 +71,7 @@ impl BenchTest {
         let canbench: &'static str = env!("CARGO_BIN_EXE_canbench");
 
         // Create a temporary directory in case no specific directory is specified.
-        let dir = TempDir::new("").unwrap();
+        let dir = tempdir().unwrap();
 
         let dir_path = match &self.base_dir {
             BaseDir::Temp => dir.path(),

--- a/canbench-rs/Cargo.toml
+++ b/canbench-rs/Cargo.toml
@@ -2,6 +2,7 @@
 name = "canbench"
 version = "0.1.0"
 edition = "2021"
+license = "Apache-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
- Adds license information to `Cargo.toml` so that the packages can be processed by tools like `cargo deny`.
- Removes the `tempdir` dependency as it was flagged as unmaintained by `cargo audit`.