### PR TITLE
chore: rename canbench rust library to canbench-rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,21 +178,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
-name = "canbench"
-version = "0.1.0"
-dependencies = [
- "canbench-macros",
- "candid",
- "ic-cdk",
- "ic-cdk-macros",
- "serde",
-]
-
-[[package]]
 name = "canbench-bin"
 version = "0.1.0"
 dependencies = [
- "canbench",
+ "canbench-rs",
  "candid",
  "clap",
  "colored",
@@ -209,7 +198,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "canbench-macros"
+name = "canbench-rs"
+version = "0.1.0"
+dependencies = [
+ "canbench-rs-macros",
+ "candid",
+ "ic-cdk",
+ "ic-cdk-macros",
+ "serde",
+]
+
+[[package]]
+name = "canbench-rs-macros"
 version = "0.1.0"
 dependencies = [
  "proc-macro2",
@@ -424,7 +424,7 @@ dependencies = [
 name = "example"
 version = "0.1.0"
 dependencies = [
- "canbench",
+ "canbench-rs",
  "candid",
  "ic-cdk",
  "ic-cdk-macros",
@@ -1330,7 +1330,7 @@ dependencies = [
 name = "tests"
 version = "0.1.0"
 dependencies = [
- "canbench",
+ "canbench-rs",
  "candid",
  "ic-cdk",
  "serde",

--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ A single message execution must stay within the allowed bounds, otherwise it's t
 cargo install canbench
 ```
 
-## Quickstart
+## Quickstart (Rust)
 
-See the [crate's documentation](https://docs.rs/canbench).
+See the [crate's documentation](https://docs.rs/canbench-rs).
 
 ## Github CI Support
 

--- a/canbench-bin/Cargo.toml
+++ b/canbench-bin/Cargo.toml
@@ -9,7 +9,7 @@ name = "canbench"
 path = "src/main.rs"
 
 [dependencies]
-canbench = { path = "../canbench-rs" }
+canbench-rs = { path = "../canbench-rs" }
 candid.workspace = true
 clap.workspace = true
 colored.workspace = true

--- a/canbench-bin/src/lib.rs
+++ b/canbench-bin/src/lib.rs
@@ -1,5 +1,5 @@
 //! A module for running benchmarks.
-use canbench::BenchResult;
+use canbench_rs::BenchResult;
 use candid::Decode;
 use flate2::read::GzDecoder;
 use std::{

--- a/canbench-bin/src/print_benchmark.rs
+++ b/canbench-bin/src/print_benchmark.rs
@@ -1,4 +1,4 @@
-use canbench::{BenchResult, Measurement};
+use canbench_rs::{BenchResult, Measurement};
 use colored::Colorize;
 
 // The threshold that determines whether or not a change is significant.

--- a/canbench-bin/src/results_file.rs
+++ b/canbench-bin/src/results_file.rs
@@ -1,4 +1,4 @@
-use canbench::BenchResult;
+use canbench_rs::BenchResult;
 use semver::Version;
 use serde::{Deserialize, Serialize};
 use std::{

--- a/canbench-rs-macros/Cargo.toml
+++ b/canbench-rs-macros/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "canbench-macros"
+name = "canbench-rs-macros"
 version = "0.1.0"
 edition = "2021"
 
@@ -11,4 +11,4 @@ proc-macro = true
 [dependencies]
 proc-macro2.workspace = true
 quote.workspace = true
-syn.workspace = true
+syn = { workspace = true, features=["full"] }

--- a/canbench-rs-macros/src/lib.rs
+++ b/canbench-rs-macros/src/lib.rs
@@ -36,7 +36,7 @@ pub fn bench(arg_tokens: TokenStream, item: TokenStream) -> TokenStream {
             // If the argument is "raw", validate that the function returns BenchResult
             if let ReturnType::Type(_, ty) = output {
                 if ty.to_token_stream().to_string() != quote!(BenchResult).to_string()
-                    && ty.to_token_stream().to_string() != quote!(canbench::BenchResult).to_string()
+                    && ty.to_token_stream().to_string() != quote!(canbench_rs::BenchResult).to_string()
                 {
                     // If the return type is not BenchResult, generate a compile-time error
                     return syn::Error::new_spanned(ty, "Raw benchmark should return BenchResult.")
@@ -55,7 +55,7 @@ pub fn bench(arg_tokens: TokenStream, item: TokenStream) -> TokenStream {
 
                 #[ic_cdk::query]
                 #[allow(non_snake_case)]
-                fn #renamed_func_name() -> canbench::BenchResult {
+                fn #renamed_func_name() -> canbench_rs::BenchResult {
                     #func_name()
                 }
             }
@@ -74,8 +74,8 @@ pub fn bench(arg_tokens: TokenStream, item: TokenStream) -> TokenStream {
 
                 #[ic_cdk::query]
                 #[allow(non_snake_case)]
-                fn #renamed_func_name() -> canbench::BenchResult {
-                    canbench::bench_fn(|| {
+                fn #renamed_func_name() -> canbench_rs::BenchResult {
+                    canbench_rs::bench_fn(|| {
                         #func_name();
                     })
                 }

--- a/canbench-rs-macros/src/lib.rs
+++ b/canbench-rs-macros/src/lib.rs
@@ -36,7 +36,8 @@ pub fn bench(arg_tokens: TokenStream, item: TokenStream) -> TokenStream {
             // If the argument is "raw", validate that the function returns BenchResult
             if let ReturnType::Type(_, ty) = output {
                 if ty.to_token_stream().to_string() != quote!(BenchResult).to_string()
-                    && ty.to_token_stream().to_string() != quote!(canbench_rs::BenchResult).to_string()
+                    && ty.to_token_stream().to_string()
+                        != quote!(canbench_rs::BenchResult).to_string()
                 {
                     // If the return type is not BenchResult, generate a compile-time error
                     return syn::Error::new_spanned(ty, "Raw benchmark should return BenchResult.")

--- a/canbench-rs/Cargo.toml
+++ b/canbench-rs/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "canbench"
+name = "canbench-rs"
 version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
@@ -7,11 +7,10 @@ license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [lib]
-name = "canbench"
 path = "src/lib.rs"
 
 [dependencies]
-canbench-macros = { path = "../canbench-rs-macros" }
+canbench-rs-macros = { path = "../canbench-rs-macros" }
 candid.workspace = true
 ic-cdk.workspace= true
 serde.workspace = true

--- a/canbench-rs/src/lib.rs
+++ b/canbench-rs/src/lib.rs
@@ -30,7 +30,7 @@
 //!
 //! ```yml
 //! build_cmd:
-//!   cargo build --release --target wasm32-unknown-unknown --features canbench
+//!   cargo build --release --target wasm32-unknown-unknown --features canbench-rs
 //!
 //! wasm_path:
 //!   ./target/wasm32-unknown-unknown/release/<YOUR_CANISTER>.wasm
@@ -67,7 +67,7 @@
 //! Now, let's add some benchmarks to this query:
 //!
 //! ```rust
-//! #[cfg(feature = "canbench")]
+//! #[cfg(feature = "canbench-rs")]
 //! mod benches {
 //!     use super::*;
 //!     use canbench_rs::bench;
@@ -244,7 +244,7 @@
 //! Let's say we want to benchmark how long it takes to run the `pre_upgrade` function. We can define the following benchmark:
 //!
 //! ```rust
-//! #[cfg(feature = "canbench")]
+//! #[cfg(feature = "canbench-rs")]
 //! mod benches {
 //!     use super::*;
 //!     use canbench_rs::bench;
@@ -267,7 +267,7 @@
 //! To address this, we can use the `#[bench(raw)]` macro to specify exactly which code we'd like to benchmark.
 //!
 //! ```rust
-//! #[cfg(feature = "canbench")]
+//! #[cfg(feature = "canbench-rs")]
 //! mod benches {
 //!     use super::*;
 //!     use canbench_rs::bench;
@@ -340,13 +340,13 @@
 //! fn pre_upgrade() {
 //!     // Serialize state.
 //!     let bytes = {
-//!         #[cfg(feature = "canbench")]
+//!         #[cfg(feature = "canbench-rs")]
 //!         let _p = canbench_rs::bench_scope("serialize_state");
 //!         STATE.with(|s| Encode!(s).unwrap())
 //!     };
 //!
 //!     // Write to stable memory.
-//!     #[cfg(feature = "canbench")]
+//!     #[cfg(feature = "canbench-rs")]
 //!     let _p = canbench_rs::bench_scope("writing_to_stable_memory");
 //!     ic_cdk::api::stable::StableWriter::default()
 //!         .write(&bytes)

--- a/canbench-rs/src/lib.rs
+++ b/canbench-rs/src/lib.rs
@@ -19,7 +19,7 @@
 //! For more information about optional dependencies, you can read more about them [here](https://doc.rust-lang.org/cargo/reference/features.html#optional-dependencies).
 //!
 //! ```toml
-//! canbench = { version = "x.y.z", optional = true }
+//! canbench_rs = { version = "x.y.z", optional = true }
 //! ```
 //!
 //! ### 3. Add a configuration to `canbench.yml`
@@ -70,7 +70,7 @@
 //! #[cfg(feature = "canbench")]
 //! mod benches {
 //!     use super::*;
-//!     use canbench::bench;
+//!     use canbench_rs::bench;
 //!
 //!     # fn fibonacci(_: u32) -> u32 { 0 }
 //!
@@ -247,7 +247,7 @@
 //! #[cfg(feature = "canbench")]
 //! mod benches {
 //!     use super::*;
-//!     use canbench::bench;
+//!     use canbench_rs::bench;
 //!
 //!     # fn initialize_state() {}
 //!     # fn pre_upgrade() {}
@@ -270,24 +270,24 @@
 //! #[cfg(feature = "canbench")]
 //! mod benches {
 //!     use super::*;
-//!     use canbench::bench;
+//!     use canbench_rs::bench;
 //!
 //!     # fn initialize_state() {}
 //!     # fn pre_upgrade() {}
 //!
 //!     #[bench(raw)]
-//!     fn pre_upgrade_bench() -> canbench::BenchResult {
+//!     fn pre_upgrade_bench() -> canbench_rs::BenchResult {
 //!         // Some function that fills the state with lots of data.
 //!         initialize_state();
 //!
 //!         // Only benchmark the pre_upgrade. Initializing the state isn't
 //!         // included in the results of our benchmark.
-//!         canbench::bench_fn(pre_upgrade)
+//!         canbench_rs::bench_fn(pre_upgrade)
 //!     }
 //! }
 //! ```
 //!
-//! Running `canbench` on the example above will benchmark only the code wrapped in `canbench::bench_fn`, which in this case is the call to `pre_upgrade`.
+//! Running `canbench` on the example above will benchmark only the code wrapped in `canbench_rs::bench_fn`, which in this case is the call to `pre_upgrade`.
 //!
 //! ```txt
 //! $ canbench pre_upgrade_bench
@@ -313,7 +313,7 @@
 //! 2. Write to stable memory
 //!
 //! Suppose we're interested in understanding, within `pre_upgrade`, the resources spent in each of these steps.
-//! `canbench` allows you to do more granular benchmarking using the `canbench::bench_scope` function.
+//! `canbench` allows you to do more granular benchmarking using the `canbench_rs::bench_scope` function.
 //! Here's how we can modify our `pre_upgrade` function:
 //!
 //!
@@ -341,13 +341,13 @@
 //!     // Serialize state.
 //!     let bytes = {
 //!         #[cfg(feature = "canbench")]
-//!         let _p = canbench::bench_scope("serialize_state");
+//!         let _p = canbench_rs::bench_scope("serialize_state");
 //!         STATE.with(|s| Encode!(s).unwrap())
 //!     };
 //!
 //!     // Write to stable memory.
 //!     #[cfg(feature = "canbench")]
-//!     let _p = canbench::bench_scope("writing_to_stable_memory");
+//!     let _p = canbench_rs::bench_scope("writing_to_stable_memory");
 //!     ic_cdk::api::stable::StableWriter::default()
 //!         .write(&bytes)
 //!         .unwrap();
@@ -382,7 +382,7 @@
 //!
 //! Executed 1 of 1 benchmarks.
 //! ```
-pub use canbench_macros::bench;
+pub use canbench_rs_macros::bench;
 use candid::CandidType;
 use serde::{Deserialize, Serialize};
 use std::cell::RefCell;
@@ -452,7 +452,7 @@ pub fn bench_fn<R>(f: impl FnOnce() -> R) -> BenchResult {
 ///
 /// ```
 /// fn my_func() {
-///   let _p = canbench::bench_scope("my_scope");
+///   let _p = canbench_rs::bench_scope("my_scope");
 ///   // Do something.
 /// }
 /// ```
@@ -461,14 +461,14 @@ pub fn bench_fn<R>(f: impl FnOnce() -> R) -> BenchResult {
 ///
 /// ```
 /// fn my_func() {
-///   let _ = canbench::bench_scope("my_scope"); // Doesn't capture the scope.
+///   let _ = canbench_rs::bench_scope("my_scope"); // Doesn't capture the scope.
 ///   // Do something.
 /// }
 /// ```
 ///
 /// ```
 /// fn my_func() {
-///   canbench::bench_scope("my_scope"); // Doesn't capture the scope.
+///   canbench_rs::bench_scope("my_scope"); // Doesn't capture the scope.
 ///   // Do something.
 /// }
 /// ```

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -12,7 +12,7 @@ name = "btreemap_vs_hashmap"
 path = "btreemap_vs_hashmap/src/main.rs"
 
 [dependencies]
-canbench = { path = "../canbench-rs", optional = true }
+canbench-rs = { path = "../canbench-rs", optional = true }
 candid.workspace = true
 ic-cdk.workspace= true
 ic-cdk-macros.workspace = true

--- a/examples/btreemap_vs_hashmap/canbench.yml
+++ b/examples/btreemap_vs_hashmap/canbench.yml
@@ -1,5 +1,5 @@
 build_cmd:
-  cargo build --release --target wasm32-unknown-unknown --features canbench
+  cargo build --release --target wasm32-unknown-unknown --features canbench-rs
 
 wasm_path:
   ../../target/wasm32-unknown-unknown/release/btreemap_vs_hashmap.wasm

--- a/examples/btreemap_vs_hashmap/src/main.rs
+++ b/examples/btreemap_vs_hashmap/src/main.rs
@@ -22,20 +22,20 @@ thread_local! {
 fn pre_upgrade() {
     // Serialize state.
     let bytes = {
-        #[cfg(feature = "canbench")]
+        #[cfg(feature = "canbench-rs")]
         let _p = canbench_rs::bench_scope("serialize_state");
         STATE.with(|s| Encode!(s).unwrap())
     };
 
     // Write to stable memory.
-    #[cfg(feature = "canbench")]
+    #[cfg(feature = "canbench-rs")]
     let _p = canbench_rs::bench_scope("writing_to_stable_memory");
     ic_cdk::api::stable::StableWriter::default()
         .write(&bytes)
         .unwrap();
 }
 
-#[cfg(feature = "canbench")]
+#[cfg(feature = "canbench-rs")]
 mod benches {
     use super::*;
     use canbench_rs::bench;

--- a/examples/btreemap_vs_hashmap/src/main.rs
+++ b/examples/btreemap_vs_hashmap/src/main.rs
@@ -23,13 +23,13 @@ fn pre_upgrade() {
     // Serialize state.
     let bytes = {
         #[cfg(feature = "canbench")]
-        let _p = canbench::bench_scope("serialize_state");
+        let _p = canbench_rs::bench_scope("serialize_state");
         STATE.with(|s| Encode!(s).unwrap())
     };
 
     // Write to stable memory.
     #[cfg(feature = "canbench")]
-    let _p = canbench::bench_scope("writing_to_stable_memory");
+    let _p = canbench_rs::bench_scope("writing_to_stable_memory");
     ic_cdk::api::stable::StableWriter::default()
         .write(&bytes)
         .unwrap();
@@ -38,7 +38,7 @@ fn pre_upgrade() {
 #[cfg(feature = "canbench")]
 mod benches {
     use super::*;
-    use canbench::bench;
+    use canbench_rs::bench;
 
     // Benchmarks inserting 1 million users into the state.
     #[bench]
@@ -58,12 +58,12 @@ mod benches {
 
     // Benchmarks removing 1 million users from the state.
     #[bench(raw)]
-    fn remove_users() -> canbench::BenchResult {
+    fn remove_users() -> canbench_rs::BenchResult {
         insert_users();
 
         // Only benchmark removing users. Inserting users isn't
         // included in the results of our benchmark.
-        canbench::bench_fn(|| {
+        canbench_rs::bench_fn(|| {
             STATE.with(|s| {
                 let mut s = s.borrow_mut();
                 for i in 0..1_000_000 {
@@ -74,12 +74,12 @@ mod benches {
     }
 
     #[bench(raw)]
-    fn pre_upgrade_bench() -> canbench::BenchResult {
+    fn pre_upgrade_bench() -> canbench_rs::BenchResult {
         insert_users();
 
         // Only benchmark the pre_upgrade. Inserting users isn't
         // included in the results of our benchmark.
-        canbench::bench_fn(pre_upgrade)
+        canbench_rs::bench_fn(pre_upgrade)
     }
 }
 

--- a/examples/fibonacci/canbench.yml
+++ b/examples/fibonacci/canbench.yml
@@ -1,5 +1,5 @@
 build_cmd:
-  cargo build --release --target wasm32-unknown-unknown --features canbench
+  cargo build --release --target wasm32-unknown-unknown --features canbench-rs
 
 wasm_path:
   ../../target/wasm32-unknown-unknown/release/fibonacci.wasm

--- a/examples/fibonacci/src/main.rs
+++ b/examples/fibonacci/src/main.rs
@@ -35,7 +35,7 @@ fn fibonacci(n: u32) -> u32 {
 #[cfg(feature = "canbench")]
 mod benches {
     use super::*;
-    use canbench::bench;
+    use canbench_rs::bench;
 
     #[bench]
     fn fibonacci_20() {

--- a/examples/fibonacci/src/main.rs
+++ b/examples/fibonacci/src/main.rs
@@ -32,7 +32,7 @@ fn fibonacci(n: u32) -> u32 {
     }
 }*/
 
-#[cfg(feature = "canbench")]
+#[cfg(feature = "canbench-rs")]
 mod benches {
     use super::*;
     use canbench_rs::bench;

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -14,7 +14,7 @@ name = "gzipped_wasm"
 path = "gzipped_wasm/src/main.rs"
 
 [dependencies]
-canbench = { path = "../canbench-rs" }
+canbench-rs = { path = "../canbench-rs" }
 candid.workspace = true
 ic-cdk.workspace= true
 serde.workspace = true

--- a/tests/gzipped_wasm/src/main.rs
+++ b/tests/gzipped_wasm/src/main.rs
@@ -1,4 +1,4 @@
-use canbench::bench;
+use canbench_rs::bench;
 
 #[bench]
 fn bench_1() {}

--- a/tests/measurements_output/src/main.rs
+++ b/tests/measurements_output/src/main.rs
@@ -1,4 +1,4 @@
-use canbench::{bench, bench_fn, bench_scope, BenchResult};
+use canbench_rs::{bench, bench_fn, bench_scope, BenchResult};
 
 #[link(wasm_import_module = "ic0")]
 extern "C" {


### PR DESCRIPTION
Due to naming conflicts on crates.io, we cannot publish both the canbench
Rust library and the canbench binary with the same name.

We therefore rename the Rust library to canbench-rs.