### PR TITLE
fix: detect regressions from zero in the CI script

### DIFF
--- a/scripts/ci_run_benchmark.sh
+++ b/scripts/ci_run_benchmark.sh
@@ -57,7 +57,7 @@ if [ -f "$MAIN_BRANCH_RESULTS_FILE" ]; then
   canbench --less-verbose > $CANBENCH_OUTPUT
   popd
 
-  if grep -q "(regressed by \|(improved by" "${CANBENCH_OUTPUT}"; then
+  if grep -q "(regress\|(improved by" "${CANBENCH_OUTPUT}"; then
     echo "**Significant performance change detected! ⚠️**
     " >> $COMMENT_MESSAGE_PATH;
   else


### PR DESCRIPTION
The script failed to detect a special case of performance regression - specifically, when the regression is from zero.

The current way we check for regressions is quite brittle and is best to be addressed with error code in the future.