### PR TITLE
chore: show full error if benchmark fails to run

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,7 +179,7 @@ checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
 name = "canbench"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "canbench-rs",
  "candid",

--- a/canbench-bin/Cargo.toml
+++ b/canbench-bin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "canbench"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "Apache-2.0"
 description = "A benchmarking framework for canisters on the Internet Computer."

--- a/canbench-bin/src/lib.rs
+++ b/canbench-bin/src/lib.rs
@@ -191,10 +191,13 @@ query rwlgt-iiaaa-aaaaa-aaaaa-cai {}{} \"DIDL\x00\x00\"",
 
     // Decode the response.
     Decode!(
-        &hex::decode(&output_hex[2..]).unwrap_or_else(|_| panic!(
-            "error parsing result of benchmark {}. Output: {}",
-            bench_fn, output_str
-        )),
+        &hex::decode(&output_hex[2..]).unwrap_or_else(|_| {
+            eprintln!(
+                "Error executing benchmark {}. Error:\n{}",
+                bench_fn, output_str
+            );
+            std::process::exit(1);
+        }),
         BenchResult
     )
     .expect("error decoding benchmark result {:?}")

--- a/canbench-bin/src/lib.rs
+++ b/canbench-bin/src/lib.rs
@@ -184,19 +184,16 @@ query rwlgt-iiaaa-aaaaa-aaaaa-cai {}{} \"DIDL\x00\x00\"",
         .output()
         .unwrap();
 
+    let output_str = String::from_utf8(drun_output.stdout).unwrap();
+
     // Extract the hex response.
-    let result_hex = String::from_utf8(drun_output.stdout)
-        .unwrap()
-        .split_whitespace()
-        .last()
-        .unwrap()
-        .to_string();
+    let output_hex = output_str.split_whitespace().last().unwrap().to_string();
 
     // Decode the response.
     Decode!(
-        &hex::decode(&result_hex[2..]).unwrap_or_else(|_| panic!(
-            "error parsing result of benchmark {}. Result: {}",
-            bench_fn, result_hex
+        &hex::decode(&output_hex[2..]).unwrap_or_else(|_| panic!(
+            "error parsing result of benchmark {}. Output: {}",
+            bench_fn, output_str
         )),
         BenchResult
     )

--- a/canbench-bin/tests/tests.rs
+++ b/canbench-bin/tests/tests.rs
@@ -46,6 +46,23 @@ Benchmark: no_changes_test
 }
 
 #[test]
+fn broken_benchmark_returns_full_error() {
+    BenchTest::canister("measurements_output")
+        .with_bench("broken_benchmark")
+        .run(|output| {
+            assert_err!(
+                output,
+                "Error executing benchmark broken_benchmark. Error:
+ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
+ingress Completed: Reply: 0x4449444c0000
+Err: IC0506: Canister rwlgt-iiaaa-aaaaa-aaaaa-cai did not produce a response
+
+"
+            );
+        });
+}
+
+#[test]
 fn benchmark_reports_noisy_change() {
     BenchTest::canister("measurements_output")
         .with_bench("noisy_change_test")
@@ -277,7 +294,7 @@ fn newer_version() {
         .run(|output| {
         assert_err!(
                 output,
-                "canbench is at version 0.1.1 while the results were generated with version 99.0.0. Please upgrade canbench.
+                "canbench is at version 0.1.2 while the results were generated with version 99.0.0. Please upgrade canbench.
 "
             );
         });

--- a/canbench-bin/tests/utils.rs
+++ b/canbench-bin/tests/utils.rs
@@ -11,7 +11,13 @@ use tempfile::tempdir;
 macro_rules! assert_err {
     ($output:expr, $err_str:expr) => {
         assert_eq!($output.status.code(), Some(1), "output: {:?}", $output);
-        pretty_assertions::assert_eq!(&String::from_utf8($output.stderr).unwrap(), $err_str);
+
+        // Stderr can contain cargo specific output like compilation time, which isn't
+        // deterministic. To ensure our tests are deterministic, we only verify that the suffix of
+        // stderr matches the given error string.
+        let stderr = String::from_utf8($output.stderr).unwrap();
+        let stderr_suffix = &stderr[stderr.len() - $err_str.len()..];
+        pretty_assertions::assert_eq!(stderr_suffix, $err_str);
     };
 }
 

--- a/tests/measurements_output/src/main.rs
+++ b/tests/measurements_output/src/main.rs
@@ -77,4 +77,9 @@ fn bench_scope_exists() {
     }
 }
 
+#[export_name = "canister_query __canbench__broken_benchmark"]
+fn broken_benchmark() {
+    // This benchmark doesn't reply, and will therefore fail.
+}
+
 fn main() {}


### PR DESCRIPTION
If a benchmark fails, the error returned can be uninformative. Example:

```
error parsing result of benchmark broken_benchmark. Output: response
```

When a benchmark succeeds, it returns a hex string, which is then parsed by `canbench`. However, if the benchmark returns an error string, then `canbench` attempts to decode as hex one of the words in the error string. The current error only outputs that one word that it extracted from the error message thinking it was hex - the word "response" in the example above.

To make the error more informative, we now output the full error message.

```
Error executing benchmark broken_benchmark. Error:
ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
ingress Completed: Reply: 0x4449444c0000
Err: IC0506: Canister rwlgt-iiaaa-aaaaa-aaaaa-cai did not produce a response
```