### PR TITLE
feat: Allow reading from a custom cfg file path

### DIFF
--- a/canbench-bin/src/lib.rs
+++ b/canbench-bin/src/lib.rs
@@ -27,8 +27,15 @@ pub fn run_benchmarks(
     persist: bool,
     results_file: &PathBuf,
     verbose: bool,
+    custom_drun_path: Option<PathBuf>,
 ) {
-    maybe_download_drun(verbose);
+    let drun_path = match custom_drun_path {
+        Some(custom_drun_path) => custom_drun_path,
+        None => {
+            maybe_download_drun(verbose);
+            download_drun_path()
+        }
+    };
 
     let current_results = match results_file::read(results_file) {
         Ok(current_results) => current_results,
@@ -55,7 +62,7 @@ pub fn run_benchmarks(
         println!("---------------------------------------------------");
         println!();
 
-        let result = run_benchmark(canister_wasm_path, bench_fn);
+        let result = run_benchmark(canister_wasm_path, drun_path.clone(), bench_fn);
         print_benchmark(bench_fn, &result, current_results.get(bench_fn));
 
         results.insert(bench_fn.to_string(), result);
@@ -91,7 +98,7 @@ fn canbench_dir() -> PathBuf {
 }
 
 // Path to drun.
-fn drun_path() -> PathBuf {
+fn download_drun_path() -> PathBuf {
     canbench_dir().join("drun")
 }
 
@@ -100,7 +107,7 @@ fn maybe_download_drun(verbose: bool) {
     const DRUN_LINUX_SHA: &str = "182b800a7979e1e3e516e54e4b9980e5407ced7464c0b3aec9ff7af6e9e69a1b";
     const DRUN_MAC_SHA: &str = "8e0d0758d5a5c6f367e2c374dc7eae0106c7f46a3457f81018af6d5159d2dad4";
 
-    if drun_path().exists() {
+    if download_drun_path().exists() {
         // Drun found. Verify that it's the version we expect it to be.
         let expected_sha = match env::consts::OS {
             "linux" => DRUN_LINUX_SHA,
@@ -108,7 +115,7 @@ fn maybe_download_drun(verbose: bool) {
             _ => panic!("only linux and macos are currently supported."),
         };
 
-        let drun_sha = sha256::try_digest(drun_path()).unwrap();
+        let drun_sha = sha256::try_digest(download_drun_path()).unwrap();
 
         if drun_sha == expected_sha {
             // Shas match. No need to download drun.
@@ -146,20 +153,20 @@ fn download_drun(verbose: bool) {
         .expect("Failed to download drun");
 
     let mut decoder = GzDecoder::new(&drun_compressed[..]);
-    let mut file = File::create(drun_path()).expect("Failed to create drun file");
+    let mut file = File::create(download_drun_path()).expect("Failed to create drun file");
 
     std::io::copy(&mut decoder, &mut file).expect("Failed to write drun file");
 
     // Make the file executable.
     Command::new("chmod")
         .arg("+x")
-        .arg(drun_path())
+        .arg(download_drun_path())
         .status()
         .unwrap();
 }
 
 // Runs the given benchmark.
-fn run_benchmark(canister_wasm_path: &Path, bench_fn: &str) -> BenchResult {
+fn run_benchmark(canister_wasm_path: &Path, drun_path: PathBuf, bench_fn: &str) -> BenchResult {
     // drun is used for running the benchmark.
     // First, we create a temporary file with steps for drun to execute the benchmark.
     let mut temp_file = tempfile::Builder::new().tempfile().unwrap();
@@ -175,7 +182,7 @@ query rwlgt-iiaaa-aaaaa-aaaaa-cai {}{} \"DIDL\x00\x00\"",
     .unwrap();
 
     // Run the benchmark with drun.
-    let drun_output = Command::new(drun_path())
+    let drun_output = Command::new(drun_path)
         .args(vec![
             temp_file.into_temp_path().to_str().unwrap(),
             "--instruction-limit",

--- a/canbench-bin/src/main.rs
+++ b/canbench-bin/src/main.rs
@@ -22,25 +22,25 @@ struct Args {
 
     // If provided, use the specified configuration file instead of the default one.
     #[clap(long, value_parser = value_parser!(PathBuf))]
-    cfg_file_path: Option<PathBuf>,
+    cfg_path: Option<PathBuf>,
 }
 
 fn main() {
     let args = Args::parse();
 
-    let cfg_file_path = args
-        .cfg_file_path
+    let cfg_path = args
+        .cfg_path
         .unwrap_or_else(|| PathBuf::from(CFG_FILE_NAME));
 
     // Read and parse the configuration file.
-    let mut file = match File::open(cfg_file_path.clone()) {
+    let mut file = match File::open(cfg_path.clone()) {
         Ok(file) => file,
         Err(err) => {
             match err.kind() {
                 std::io::ErrorKind::NotFound => {
-                    eprintln!("canbench yml not found at {:?}", cfg_file_path)
+                    eprintln!("canbench yml not found at {:?}", cfg_path)
                 }
-                other => println!("Error while opening `{:?}`: {}", cfg_file_path, other),
+                other => println!("Error while opening `{:?}`: {}", cfg_path, other),
             }
 
             std::process::exit(1);
@@ -60,8 +60,6 @@ fn main() {
         cfg.get("results_path")
             .unwrap_or(&DEFAULT_RESULTS_FILE.to_string()),
     );
-
-    let custom_drun_path = cfg.get("drun_path").map(PathBuf::from);
 
     // Build the canister if a build command is specified.
     if let Some(build_cmd) = cfg.get("build_cmd") {
@@ -83,6 +81,5 @@ fn main() {
         args.persist,
         &results_path,
         !args.less_verbose,
-        custom_drun_path,
     );
 }

--- a/canbench-bin/src/main.rs
+++ b/canbench-bin/src/main.rs
@@ -33,14 +33,14 @@ fn main() {
         .unwrap_or_else(|| PathBuf::from(CFG_FILE_NAME));
 
     // Read and parse the configuration file.
-    let mut file = match File::open(cfg_file_path) {
+    let mut file = match File::open(cfg_file_path.clone()) {
         Ok(file) => file,
         Err(err) => {
             match err.kind() {
                 std::io::ErrorKind::NotFound => {
-                    eprintln!("{} not found in current directory.", CFG_FILE_NAME)
+                    eprintln!("canbench yml not found at {:?}", cfg_file_path)
                 }
-                other => println!("Error while opening `{}`: {}", CFG_FILE_NAME, other),
+                other => println!("Error while opening `{:?}`: {}", cfg_file_path, other),
             }
 
             std::process::exit(1);
@@ -61,7 +61,7 @@ fn main() {
             .unwrap_or(&DEFAULT_RESULTS_FILE.to_string()),
     );
 
-    let custom_drun_path = cfg.get("drun_path").map(|p| PathBuf::from(p));
+    let custom_drun_path = cfg.get("drun_path").map(PathBuf::from);
 
     // Build the canister if a build command is specified.
     if let Some(build_cmd) = cfg.get("build_cmd") {

--- a/canbench-bin/tests/tests.rs
+++ b/canbench-bin/tests/tests.rs
@@ -4,7 +4,7 @@ use utils::BenchTest;
 #[test]
 fn no_config_prints_error() {
     BenchTest::no_config().run(|output| {
-        assert_err!(output, "canbench.yml not found in current directory.\n");
+        assert_err!(output, "canbench yml not found at \"canbench.yml\"\n");
     });
 }
 
@@ -38,6 +38,28 @@ Benchmark: no_changes_test
     instructions: 207 (no change)
     heap_increase: 0 pages (no change)
     stable_memory_increase: 0 pages (no change)
+
+---------------------------------------------------
+"
+            );
+        });
+}
+
+#[test]
+fn benchmark_reports_custom_cfg() {
+    BenchTest::canister("custom_cfg")
+        .with_custom_cfg_file_name("custom_canbench.yml")
+        .run(|output| {
+            assert_success!(
+                output,
+                "
+---------------------------------------------------
+
+Benchmark: bench (new)
+  total:
+    instructions: 207 (new)
+    heap_increase: 0 pages (new)
+    stable_memory_increase: 0 pages (new)
 
 ---------------------------------------------------
 "

--- a/canbench-bin/tests/utils.rs
+++ b/canbench-bin/tests/utils.rs
@@ -33,6 +33,7 @@ pub struct BenchTest {
     config: Option<String>,
     bench_name: Option<String>,
     base_dir: BaseDir,
+    custom_cfg_file_name: Option<String>,
 }
 
 impl BenchTest {
@@ -41,6 +42,7 @@ impl BenchTest {
             config: None,
             bench_name: None,
             base_dir: BaseDir::Temp,
+            custom_cfg_file_name: None,
         }
     }
 
@@ -49,6 +51,7 @@ impl BenchTest {
             config: Some(config.into()),
             bench_name: None,
             base_dir: BaseDir::Temp,
+            custom_cfg_file_name: None,
         }
     }
 
@@ -63,12 +66,20 @@ impl BenchTest {
                     .join("tests")
                     .join(canister_name),
             ),
+            custom_cfg_file_name: None,
         }
     }
 
     pub fn with_bench(self, bench_name: &str) -> Self {
         Self {
             bench_name: Some(bench_name.to_string()),
+            ..self
+        }
+    }
+
+    pub fn with_custom_cfg_file_name(self, custom_cfg_file_name: &str) -> Self {
+        Self {
+            custom_cfg_file_name: Some(custom_cfg_file_name.to_string()),
             ..self
         }
     }
@@ -94,6 +105,18 @@ impl BenchTest {
         // Only output the benchmarks so that the output isn't polluted by other
         // statements (e.g. downloading runtime).
         let mut cmd_args = vec!["--less-verbose".to_string()];
+
+        // If a custom file name is provided, supply the path to the config file as an argument.
+        if let Some(custom_cfg_file_name) = self.custom_cfg_file_name {
+            cmd_args.push("--cfg-file-path".to_string());
+            cmd_args.push(
+                dir_path
+                    .join(custom_cfg_file_name)
+                    .to_string_lossy()
+                    .to_string(),
+            );
+        }
+
         if let Some(bench_name) = self.bench_name {
             cmd_args.push(bench_name.clone());
         }

--- a/canbench-bin/tests/utils.rs
+++ b/canbench-bin/tests/utils.rs
@@ -108,7 +108,7 @@ impl BenchTest {
 
         // If a custom file name is provided, supply the path to the config file as an argument.
         if let Some(custom_cfg_file_name) = self.custom_cfg_file_name {
-            cmd_args.push("--cfg-file-path".to_string());
+            cmd_args.push("--cfg-path".to_string());
             cmd_args.push(
                 dir_path
                     .join(custom_cfg_file_name)

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -13,8 +13,12 @@ path = "measurements_output/src/main.rs"
 name = "gzipped_wasm"
 path = "gzipped_wasm/src/main.rs"
 
+[[bin]]
+name = "custom_cfg"
+path = "custom_cfg/src/main.rs"
+
 [dependencies]
 canbench-rs = { path = "../canbench-rs" }
 candid.workspace = true
-ic-cdk.workspace= true
+ic-cdk.workspace = true
 serde.workspace = true

--- a/tests/custom_cfg/custom_canbench.yml
+++ b/tests/custom_cfg/custom_canbench.yml
@@ -1,0 +1,6 @@
+build_cmd:
+  cargo build --release --target wasm32-unknown-unknown
+
+wasm_path:
+  ../../target/wasm32-unknown-unknown/release/custom_cfg.wasm
+

--- a/tests/custom_cfg/src/main.rs
+++ b/tests/custom_cfg/src/main.rs
@@ -1,0 +1,6 @@
+use canbench_rs::bench;
+
+#[bench]
+fn bench() {}
+
+fn main() {}


### PR DESCRIPTION
Allow a custom cfg file path and a custom drun path in the cfg file. This is to make it possible for bazel to run canbench.