### PR TITLE
fix: posting comments from forked repos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,12 @@ jobs:
 
       - name: Benchmark
         run: |
-          bash ./scripts/ci_run_benchmark.sh $PROJECT_DIR
+          bash ./scripts/ci_run_benchmark.sh $PROJECT_DIR ${{ github.job }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: canbench_result_${{github.job}}
+          path: /tmp/canbench_result_${{ github.job }}
 
       - name: Post comment
         uses: thollander/actions-comment-pull-request@v2
@@ -118,13 +123,12 @@ jobs:
 
       - name: Benchmark
         run: |
-          bash ./scripts/ci_run_benchmark.sh $PROJECT_DIR
+          bash ./scripts/ci_run_benchmark.sh $PROJECT_DIR ${{ github.job }}
 
-      - name: Post comment
-        uses: thollander/actions-comment-pull-request@v2
+      - uses: actions/upload-artifact@v4
         with:
-          filePath: /tmp/canbench_comment_message.txt
-          comment_tag: ${{ env.PROJECT_DIR }}
+          name: canbench_result_${{github.job}}
+          path: /tmp/canbench_result_${{ github.job }}
 
       - name: Pass or fail
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,15 @@ jobs:
           name: canbench_result_${{github.job}}
           path: /tmp/canbench_result_${{ github.job }}
 
+      - name: Upload PR number
+        run: |
+          echo ${{ github.event.number }} > /tmp/pr_number
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: pr_number
+          path: /tmp/pr_number
+
       - name: Pass or fail
         run: |
           bash ./scripts/ci_post_run_benchmark.sh
@@ -123,6 +132,15 @@ jobs:
         with:
           name: canbench_result_${{github.job}}
           path: /tmp/canbench_result_${{ github.job }}
+
+      - name: Upload PR number
+        run: |
+          echo ${{ github.event.number }} > /tmp/pr_number
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: pr_number
+          path: /tmp/pr_number
 
       - name: Pass or fail
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,15 +82,6 @@ jobs:
           name: canbench_result_${{github.job}}
           path: /tmp/canbench_result_${{ github.job }}
 
-      - name: Upload PR number
-        run: |
-          echo ${{ github.event.number }} > /tmp/pr_number
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: pr_number
-          path: /tmp/pr_number
-
       - name: Pass or fail
         run: |
           bash ./scripts/ci_post_run_benchmark.sh
@@ -133,15 +124,6 @@ jobs:
           name: canbench_result_${{github.job}}
           path: /tmp/canbench_result_${{ github.job }}
 
-      - name: Upload PR number
-        run: |
-          echo ${{ github.event.number }} > /tmp/pr_number
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: pr_number
-          path: /tmp/pr_number
-
       - name: Pass or fail
         run: |
           bash ./scripts/ci_post_run_benchmark.sh
@@ -155,6 +137,21 @@ jobs:
       uses: ludeeus/action-shellcheck@master
       env:
         SHELLCHECK_OPTS: -e SC1090 -e SC2119 -e SC1091
+
+  upload-pr-number:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Save PR number
+        run: |
+          echo ${{ github.event.number }} > /tmp/pr_number
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: pr_number
+          path: /tmp/pr_number
 
   checks-pass:
     # Always run this job!

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,12 +82,6 @@ jobs:
           name: canbench_result_${{github.job}}
           path: /tmp/canbench_result_${{ github.job }}
 
-      - name: Post comment
-        uses: thollander/actions-comment-pull-request@v2
-        with:
-          filePath: /tmp/canbench_comment_message.txt
-          comment_tag: ${{ env.PROJECT_DIR }}
-
       - name: Pass or fail
         run: |
           bash ./scripts/ci_post_run_benchmark.sh

--- a/scripts/ci_run_benchmark.sh
+++ b/scripts/ci_run_benchmark.sh
@@ -7,8 +7,11 @@ set -Eexuo pipefail
 # Path to run `canbench` from.
 CANISTER_PATH=$1
 
+# The name of the job in CI
+CANBENCH_JOB_NAME=$2
+
 # Must match the file specified in the github action.
-COMMENT_MESSAGE_PATH=/tmp/canbench_comment_message.txt
+COMMENT_MESSAGE_PATH=/tmp/canbench_result_${CANBENCH_JOB_NAME}
 
 # Github CI is expected to have the main branch checked out in this folder.
 MAIN_BRANCH_DIR=_canbench_main_branch
@@ -45,7 +48,7 @@ fi
 popd
 
 
-echo "# \`canbench\` 🏋 (dir: $CANISTER_PATH)" > $COMMENT_MESSAGE_PATH
+echo "# \`canbench\` 🏋 (dir: $CANISTER_PATH)" > "$COMMENT_MESSAGE_PATH"
 
 # Detect if there are performance changes relative to the main branch.
 if [ -f "$MAIN_BRANCH_RESULTS_FILE" ]; then
@@ -54,15 +57,15 @@ if [ -f "$MAIN_BRANCH_RESULTS_FILE" ]; then
 
   # Run canbench to compare result to main branch.
   pushd "$CANISTER_PATH"
-  canbench --less-verbose > $CANBENCH_OUTPUT
+  canbench --less-verbose > "$CANBENCH_OUTPUT"
   popd
 
   if grep -q "(regress\|(improved by" "${CANBENCH_OUTPUT}"; then
     echo "**Significant performance change detected! ⚠️**
-    " >> $COMMENT_MESSAGE_PATH;
+    " >> "$COMMENT_MESSAGE_PATH"
   else
     echo "**No significant performance changes detected ✅**
-    " >> $COMMENT_MESSAGE_PATH
+    " >> "$COMMENT_MESSAGE_PATH"
   fi
 fi
 
@@ -73,7 +76,7 @@ fi
   echo "\`\`\`"
   cat "$CANBENCH_OUTPUT"
   echo "\`\`\`"
-} >> $COMMENT_MESSAGE_PATH
+} >> "$COMMENT_MESSAGE_PATH"
 
 # Output the comment to stdout.
-cat $COMMENT_MESSAGE_PATH
+cat "$COMMENT_MESSAGE_PATH"


### PR DESCRIPTION
This PR builds on #43 to update the CI such that canbench can post comments from forked PRs.