### PR TITLE
chore: update version of canbench

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,7 +179,7 @@ checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
 name = "canbench"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "canbench-rs",
  "candid",

--- a/canbench-bin/Cargo.toml
+++ b/canbench-bin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "canbench"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 license = "Apache-2.0"
 description = "A benchmarking framework for canisters on the Internet Computer."

--- a/canbench-bin/tests/tests.rs
+++ b/canbench-bin/tests/tests.rs
@@ -294,7 +294,7 @@ fn newer_version() {
         .run(|output| {
         assert_err!(
                 output,
-                "canbench is at version 0.1.2 while the results were generated with version 99.0.0. Please upgrade canbench.
+                "canbench is at version 0.1.3 while the results were generated with version 99.0.0. Please upgrade canbench.
 "
             );
         });


### PR DESCRIPTION
Updates the version of canbench to release it with the change in #47.