### PR TITLE
chore: bump version to 0.1.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,7 +200,7 @@ checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
 name = "canbench"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "canbench-rs",
  "candid",

--- a/canbench-bin/Cargo.toml
+++ b/canbench-bin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "canbench"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 license = "Apache-2.0"
 description = "A benchmarking framework for canisters on the Internet Computer."

--- a/canbench-bin/tests/tests.rs
+++ b/canbench-bin/tests/tests.rs
@@ -291,7 +291,7 @@ fn newer_version() {
         .run(|output| {
         assert_err!(
                 output,
-                "canbench is at version 0.1.3 while the results were generated with version 99.0.0. Please upgrade canbench.
+                "canbench is at version 0.1.4 while the results were generated with version 99.0.0. Please upgrade canbench.
 "
             );
         });


### PR DESCRIPTION
Some notable changes have been introduced that are worthy of a new release:

1. Support for init args.
2. Switching the runtime from `drun` to `PocketIC`