### PR TITLE
chore: update version of canbench-rs to 0.1.4

### DIFF
--- a/canbench-rs-macros/Cargo.toml
+++ b/canbench-rs-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "canbench-rs-macros"
-version = "0.1.0"
+version = "0.1.4"
 edition = "2021"
 license = "Apache-2.0"
 description = "Macros for canbench-rs"

--- a/canbench-rs/Cargo.toml
+++ b/canbench-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "canbench-rs"
-version = "0.1.0"
+version = "0.1.4"
 edition = "2021"
 license = "Apache-2.0"
 description = "The rust library for `canbench`, the benchmarking framework for canisters on the Internet Computer."


### PR DESCRIPTION
NOTE: Version 0.1.0 is updated to 0.1.4, which makes these libraries have exactly the same version number as the canbench binary. Unifying the versions allows us to more easily manage released on github and on crates.io