### PR TITLE
fix(ci): Sanitize PR title by using ENV variable

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -16,7 +16,7 @@ env:
   CARGO_NET_RETRY: 10
   # Use the local .curlrc
   CURL_HOME: .
-
+  TITLE: ${{ github.event.pull_request.title }}
 jobs:
   check:
     name: conventional-pr-title:required
@@ -31,10 +31,9 @@ jobs:
         # scope: refers to the part of code being changed.  E.g. " (accounts)" or " (accounts,canisters)"
         # !: Indicates that the PR contains a breaking change.
       - run: |
-          if [[ "${{ github.event.pull_request.title }}" =~ ^(feat|fix|chore|build|ci|docs|style|refactor|perf|test)(\([-a-zA-Z0-9,]+\))?\!?\: ]]; then
+          if [[ "$TITLE" =~ ^(feat|fix|chore|build|ci|docs|style|refactor|perf|test)(\([-a-zA-Z0-9,]+\))?\!?\: ]]; then
               echo pass
           else
               echo "PR title does not match conventions"
-              echo "PR title: ${{ github.event.pull_request.title }}"
               exit 1
           fi


### PR DESCRIPTION
We need to sanitize the PR title by leveraging an environment variable as an intermediate step to prevent potential script injection attacks. This additional measure enhances the security of the workflow.