### PR TITLE
fix: correctly account for instructions when writing stable memory

### DIFF
--- a/canbench-bin/src/lib.rs
+++ b/canbench-bin/src/lib.rs
@@ -253,7 +253,7 @@ fn init_pocket_ic(canister_wasm_path: &PathBuf, init_args: Vec<u8>) -> (PocketIc
     std::env::set_var("POCKET_IC_MUTE_SERVER", "1");
     let pocket_ic = PocketIcBuilder::new()
         .with_max_request_time_ms(None)
-        .with_benchmarking_system_subnet()
+        .with_benchmarking_application_subnet()
         .build();
     let canister_id = pocket_ic.create_canister();
     pocket_ic.add_cycles(canister_id, 1_000_000_000_000_000);

--- a/canbench-bin/tests/tests.rs
+++ b/canbench-bin/tests/tests.rs
@@ -318,3 +318,26 @@ Benchmark: state_check
             );
         });
 }
+
+// Ensures writes to stable memory are accounted for in the same way as application subnets.
+#[test]
+fn benchmark_stable_writes() {
+    BenchTest::canister("measurements_output")
+        .with_bench("write_stable_memory")
+        .run(|output| {
+            assert_success!(
+                output,
+                "
+---------------------------------------------------
+
+Benchmark: write_stable_memory (new)
+  total:
+    instructions: 49.09 K (new)
+    heap_increase: 0 pages (new)
+    stable_memory_increase: 1 pages (new)
+
+---------------------------------------------------
+"
+            );
+        });
+}

--- a/tests/measurements_output/src/main.rs
+++ b/tests/measurements_output/src/main.rs
@@ -3,6 +3,7 @@ use canbench_rs::{bench, bench_fn, bench_scope, BenchResult};
 #[link(wasm_import_module = "ic0")]
 extern "C" {
     pub fn stable64_grow(additional_pages: u64) -> i64;
+    pub fn stable64_write(offset: i64, src: i64, size: i64);
 }
 
 // A benchmark that does nothing.
@@ -47,6 +48,17 @@ fn stable_memory_only_increase() -> BenchResult {
 #[bench]
 fn increase_heap_increase() {
     let _ = vec![1; 1_000_000];
+}
+
+// A benchmark where some bytes are written to stable memory.
+#[bench]
+fn write_stable_memory() {
+    let v = vec![1; 10_000];
+
+    unsafe {
+        stable64_grow(1);
+        stable64_write(0, v.as_ptr() as i64, v.len() as i64);
+    }
 }
 
 // A benchmark that includes some profiling, but isn't persisted in the results.


### PR DESCRIPTION
## Problem
canbench was formerly using a system subnet to benchmark instructions. As noted in #61, there are differences between how instructions are accounted in system subnets vs application subnets, where the application subnets are more accurate, especially when it comes to accounting for stable memory writes.

## Solution
Use an application subnet configuration rather than a system subnet to more correctly account instructions.

Closes #61 