### PR TITLE
fix: use canbench from HEAD in CI

### DIFF
--- a/examples/btreemap_vs_hashmap/canbench_results.yml
+++ b/examples/btreemap_vs_hashmap/canbench_results.yml
@@ -7,16 +7,16 @@ benches:
     scopes: {}
   pre_upgrade_bench:
     total:
-      instructions: 729107478
+      instructions: 743977526
       heap_increase: 519
       stable_memory_increase: 184
     scopes:
       serialize_state:
-        instructions: 729104959
+        instructions: 729045047
         heap_increase: 519
         stable_memory_increase: 0
       writing_to_stable_memory:
-        instructions: 506
+        instructions: 14930540
         heap_increase: 0
         stable_memory_increase: 184
   remove_users:
@@ -25,4 +25,4 @@ benches:
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
-version: 0.1.1
+version: 0.1.5

--- a/scripts/ci_run_benchmark.sh
+++ b/scripts/ci_run_benchmark.sh
@@ -21,8 +21,9 @@ CANBENCH_OUTPUT=/tmp/canbench_output.txt
 CANBENCH_RESULTS_FILE="$CANISTER_PATH/canbench_results.yml"
 MAIN_BRANCH_RESULTS_FILE="$MAIN_BRANCH_DIR/$CANBENCH_RESULTS_FILE"
 
-# Install canbench
-cargo install canbench
+# Install canbench.
+# NOTE: canbench-bin from HEAD is used, and not the version deployes to crates.io
+cargo install --path canbench-bin
 
 # Verify that canbench results are available.
 if [ ! -f "$CANBENCH_RESULTS_FILE" ]; then


### PR DESCRIPTION
## Problem
The CI is downloading a version of canbench from crates.io, which means the benchmarks do not capture any performance changes from the current PR.

## Solution
Update the CI script to build canbench from HEAD.

Note the regression in the btreemap example due to the change in pricing of stable memory operations in later versions of canbench.