### PR TITLE
feat: switch to composite queries for benchmarks

### DIFF
--- a/canbench-rs-macros/src/lib.rs
+++ b/canbench-rs-macros/src/lib.rs
@@ -54,7 +54,7 @@ pub fn bench(arg_tokens: TokenStream, item: TokenStream) -> TokenStream {
             quote! {
                 #input
 
-                #[ic_cdk::query]
+                #[ic_cdk::query(composite = true)]
                 #[allow(non_snake_case)]
                 fn #renamed_func_name() -> canbench_rs::BenchResult {
                     #func_name()
@@ -73,7 +73,7 @@ pub fn bench(arg_tokens: TokenStream, item: TokenStream) -> TokenStream {
             quote! {
                 #input
 
-                #[ic_cdk::query]
+                #[ic_cdk::query(composite = true)]
                 #[allow(non_snake_case)]
                 fn #renamed_func_name() -> canbench_rs::BenchResult {
                     canbench_rs::bench_fn(|| {


### PR DESCRIPTION
This allows benchmarks to include query calls.