### PR TITLE
feat: Support custom noise threshold

### DIFF
--- a/canbench-bin/src/lib.rs
+++ b/canbench-bin/src/lib.rs
@@ -31,6 +31,7 @@ pub fn run_benchmarks(
     integrity_check: bool,
     runtime_path: &PathBuf,
     stable_memory_path: Option<PathBuf>,
+    noise_threshold: f64,
 ) {
     maybe_download_pocket_ic(runtime_path, verbose, integrity_check);
 
@@ -71,7 +72,12 @@ pub fn run_benchmarks(
         println!();
 
         let result = run_benchmark(&pocket_ic, canister_id, bench_fn);
-        print_benchmark(bench_fn, &result, current_results.get(bench_fn));
+        print_benchmark(
+            bench_fn,
+            &result,
+            current_results.get(bench_fn),
+            noise_threshold,
+        );
 
         results.insert(bench_fn.to_string(), result);
         num_executed_bench_fns += 1;

--- a/canbench-bin/src/main.rs
+++ b/canbench-bin/src/main.rs
@@ -6,8 +6,6 @@ use std::{fs::File, io::Read, path::PathBuf, process::Command};
 
 const CFG_FILE_NAME: &str = "canbench.yml";
 const DEFAULT_RESULTS_FILE: &str = "canbench_results.yml";
-// The default threshold that determines whether or not a change is significant.
-const DEFAULT_NOISE_THRESHOLD: f64 = 2.0;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -38,8 +36,9 @@ struct Args {
     #[clap(long)]
     runtime_path: Option<PathBuf>,
 
-    #[clap(long)]
-    custom_noise_threshold: Option<f64>,
+    /// A threshold (in percentage), below which a change in benchmark results is considered noise.
+    #[clap(long, default_value = "2.0")]
+    noise_threshold: f64,
 }
 
 #[derive(Debug, Deserialize)]
@@ -145,7 +144,6 @@ fn main() {
         !args.no_runtime_integrity_check,
         &args.runtime_path.unwrap_or_else(default_runtime_path),
         stable_memory_path,
-        args.custom_noise_threshold
-            .unwrap_or(DEFAULT_NOISE_THRESHOLD),
+        args.noise_threshold,
     );
 }

--- a/canbench-bin/src/main.rs
+++ b/canbench-bin/src/main.rs
@@ -6,6 +6,8 @@ use std::{fs::File, io::Read, path::PathBuf, process::Command};
 
 const CFG_FILE_NAME: &str = "canbench.yml";
 const DEFAULT_RESULTS_FILE: &str = "canbench_results.yml";
+// The default threshold that determines whether or not a change is significant.
+const DEFAULT_NOISE_THRESHOLD: f64 = 2.0;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -35,6 +37,9 @@ struct Args {
     /// Defaults to `.canbench/pocket-ic`.
     #[clap(long)]
     runtime_path: Option<PathBuf>,
+
+    #[clap(long)]
+    custom_noise_threshold: Option<f64>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -140,5 +145,7 @@ fn main() {
         !args.no_runtime_integrity_check,
         &args.runtime_path.unwrap_or_else(default_runtime_path),
         stable_memory_path,
+        args.custom_noise_threshold
+            .unwrap_or(DEFAULT_NOISE_THRESHOLD),
     );
 }

--- a/canbench-bin/tests/tests.rs
+++ b/canbench-bin/tests/tests.rs
@@ -83,6 +83,51 @@ Benchmark: noisy_change_test
 }
 
 #[test]
+fn benchmark_reports_noisy_change_above_default_noise_threshold() {
+    BenchTest::canister("measurements_output")
+        .with_bench("noisy_change_above_default_threshold_test")
+        .run(|output| {
+            assert_success!(
+                output,
+                "
+---------------------------------------------------
+
+Benchmark: noisy_change_above_default_threshold_test
+  total:
+    instructions: 3.39 M (improved by 4.36%)
+    heap_increase: 62 pages (improved by 4.62%)
+    stable_memory_increase: 100 pages (improved by 3.85%)
+
+---------------------------------------------------
+"
+            );
+        });
+}
+
+#[test]
+fn benchmark_reports_noisy_change_within_custom_noise_threshold() {
+    BenchTest::canister("measurements_output")
+        .with_bench("noisy_change_above_default_threshold_test")
+        .with_noise_threshold(5.0)
+        .run(|output| {
+            assert_success!(
+                output,
+                "
+---------------------------------------------------
+
+Benchmark: noisy_change_above_default_threshold_test
+  total:
+    instructions: 3.39 M (-4.36%) (change within noise threshold)
+    heap_increase: 62 pages (-4.62%) (change within noise threshold)
+    stable_memory_increase: 100 pages (-3.85%) (change within noise threshold)
+
+---------------------------------------------------
+"
+            );
+        });
+}
+
+#[test]
 fn benchmark_reports_regression() {
     BenchTest::canister("measurements_output")
         .with_bench("regression_test")

--- a/canbench-bin/tests/utils.rs
+++ b/canbench-bin/tests/utils.rs
@@ -44,6 +44,7 @@ pub struct BenchTest {
     base_dir: BaseDir,
     runtime_path: Option<PathBuf>,
     no_runtime_integrity_check: bool,
+    noise_threshold: Option<f64>,
 }
 
 impl BenchTest {
@@ -54,6 +55,7 @@ impl BenchTest {
             base_dir: BaseDir::Temp,
             runtime_path: None,
             no_runtime_integrity_check: false,
+            noise_threshold: None,
         }
     }
 
@@ -64,6 +66,7 @@ impl BenchTest {
             base_dir: BaseDir::Temp,
             runtime_path: None,
             no_runtime_integrity_check: false,
+            noise_threshold: None,
         }
     }
 
@@ -80,6 +83,7 @@ impl BenchTest {
             ),
             runtime_path: None,
             no_runtime_integrity_check: false,
+            noise_threshold: None,
         }
     }
 
@@ -100,6 +104,13 @@ impl BenchTest {
     pub fn with_no_runtime_integrity_check(self) -> Self {
         Self {
             no_runtime_integrity_check: true,
+            ..self
+        }
+    }
+
+    pub fn with_noise_threshold(self, noise_threshold: f64) -> Self {
+        Self {
+            noise_threshold: Some(noise_threshold),
             ..self
         }
     }
@@ -136,6 +147,11 @@ impl BenchTest {
 
         if self.no_runtime_integrity_check {
             cmd_args.push("--no-runtime-integrity-check".to_string());
+        }
+
+        if let Some(noise_threshold) = self.noise_threshold {
+            cmd_args.push("--custom-noise-threshold".to_string());
+            cmd_args.push(noise_threshold.to_string());
         }
 
         let output = Command::new(canbench)

--- a/canbench-bin/tests/utils.rs
+++ b/canbench-bin/tests/utils.rs
@@ -150,7 +150,7 @@ impl BenchTest {
         }
 
         if let Some(noise_threshold) = self.noise_threshold {
-            cmd_args.push("--custom-noise-threshold".to_string());
+            cmd_args.push("--noise-threshold".to_string());
             cmd_args.push(noise_threshold.to_string());
         }
 

--- a/tests/measurements_output/canbench_results.yml
+++ b/tests/measurements_output/canbench_results.yml
@@ -15,6 +15,13 @@ benches:
       instructions: 210
       stable_memory_increase: 0
 
+  # A benchmark that is expected to return a noisy change with a higher noise threshold.
+  noisy_change_above_default_threshold_test:
+    total:
+      heap_increase: 65 
+      instructions: 3540000
+      stable_memory_increase: 104
+
   # A benchmark that is expected to return a regression.
   regression_test:
     total:

--- a/tests/measurements_output/src/main.rs
+++ b/tests/measurements_output/src/main.rs
@@ -16,6 +16,16 @@ fn no_changes_test() {}
 #[bench]
 fn noisy_change_test() {}
 
+// A benchmark that uses large enough number of instructions, heap and stable memory so that cases
+// related to noise threshold can be tested. The values of the benchmark are persisted such that a
+// noisy change is reported with a higher noise threshold, while significant change is reported with
+// the default noise threshold.
+#[bench]
+fn noisy_change_above_default_threshold_test() {
+    let _ = vec![1; 1_000_000];
+    unsafe { stable64_grow(100) };
+}
+
 // A benchmark that does nothing.
 // The values of the benchmark are persisted such that regression is reported.
 #[bench]


### PR DESCRIPTION
# Why

For some projects, there are some small variances in the performance, and from time to time people have to update the results for small changes. For projects with more frequent commits, the chances of having conflicts is greater, and the convenience of avoiding such conflicts sometimes outweighs the benefits of detecting small performance changes.

# What

- Add `--custom-noise-threshold` CLI option
- Use the custom threshold if it exists
- Add tests

# Alternative Considered

One alternative is to add the argument to `Config` instead. There doesn't seem to be a clear pros/cons for whether to add to CLI or Config. For IC monorepo, it's easier to use CLI option because of bazel.