### PR TITLE
ci: Upgrade Rust toolchain to 1.84

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 on: [pull_request]
 
 env:
-  RUST_VERSION: 1.75.0
+  RUST_VERSION: 1.81.0
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 on: [pull_request]
 
 env:
-  RUST_VERSION: 1.81.0
+  RUST_VERSION: 1.84.0
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Cache Cargo
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,7 +200,7 @@ checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
 name = "canbench"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "canbench-rs",
  "candid",
@@ -221,7 +221,7 @@ dependencies = [
 
 [[package]]
 name = "canbench-rs"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "canbench-rs-macros",
  "candid",
@@ -232,7 +232,7 @@ dependencies = [
 
 [[package]]
 name = "canbench-rs-macros"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/canbench-bin/tests/tests.rs
+++ b/canbench-bin/tests/tests.rs
@@ -400,7 +400,7 @@ fn benchmark_works_with_init_args() {
 
 Benchmark: state_check
   total:
-    instructions: 930 (regressed by 15.67%)
+    instructions: 930 (regressed by 7.27%)
     heap_increase: 0 pages (no change)
     stable_memory_increase: 0 pages (no change)
 

--- a/canbench-bin/tests/tests.rs
+++ b/canbench-bin/tests/tests.rs
@@ -279,17 +279,17 @@ fn reports_scopes_in_new_benchmark() {
 
 Benchmark: bench_scope_new (new)
   total:
-    instructions: 3579 (new)
+    instructions: 3165 (new)
     heap_increase: 0 pages (new)
     stable_memory_increase: 0 pages (new)
 
   scope_1 (scope):
-    instructions: 1286 (new)
+    instructions: 913 (new)
     heap_increase: 0 pages (new)
     stable_memory_increase: 0 pages (new)
 
   scope_2 (scope):
-    instructions: 740 (new)
+    instructions: 714 (new)
     heap_increase: 0 pages (new)
     stable_memory_increase: 0 pages (new)
 
@@ -356,17 +356,17 @@ fn reports_scopes_in_existing_benchmark() {
 
 Benchmark: bench_scope_exists
   total:
-    instructions: 3579 (regressed from 0)
+    instructions: 3165 (regressed from 0)
     heap_increase: 0 pages (no change)
     stable_memory_increase: 0 pages (no change)
 
   scope_1 (scope):
-    instructions: 1286 (regressed by 60.75%)
+    instructions: 913 (regressed by 14.12%)
     heap_increase: 0 pages (improved by 100.00%)
     stable_memory_increase: 0 pages (no change)
 
   scope_2 (scope):
-    instructions: 740 (new)
+    instructions: 714 (new)
     heap_increase: 0 pages (new)
     stable_memory_increase: 0 pages (new)
 
@@ -400,7 +400,7 @@ fn benchmark_works_with_init_args() {
 
 Benchmark: state_check
   total:
-    instructions: 930 (regressed by 7.27%)
+    instructions: 872 (no change)
     heap_increase: 0 pages (no change)
     stable_memory_increase: 0 pages (no change)
 

--- a/canbench-bin/tests/tests.rs
+++ b/canbench-bin/tests/tests.rs
@@ -279,17 +279,17 @@ fn reports_scopes_in_new_benchmark() {
 
 Benchmark: bench_scope_new (new)
   total:
-    instructions: 3411 (new)
+    instructions: 3579 (new)
     heap_increase: 0 pages (new)
     stable_memory_increase: 0 pages (new)
 
   scope_1 (scope):
-    instructions: 1002 (new)
+    instructions: 1286 (new)
     heap_increase: 0 pages (new)
     stable_memory_increase: 0 pages (new)
 
   scope_2 (scope):
-    instructions: 787 (new)
+    instructions: 740 (new)
     heap_increase: 0 pages (new)
     stable_memory_increase: 0 pages (new)
 
@@ -356,17 +356,17 @@ fn reports_scopes_in_existing_benchmark() {
 
 Benchmark: bench_scope_exists
   total:
-    instructions: 3411 (regressed from 0)
+    instructions: 3579 (regressed from 0)
     heap_increase: 0 pages (no change)
     stable_memory_increase: 0 pages (no change)
 
   scope_1 (scope):
-    instructions: 1002 (regressed by 25.25%)
+    instructions: 1286 (regressed by 60.75%)
     heap_increase: 0 pages (improved by 100.00%)
     stable_memory_increase: 0 pages (no change)
 
   scope_2 (scope):
-    instructions: 787 (new)
+    instructions: 740 (new)
     heap_increase: 0 pages (new)
     stable_memory_increase: 0 pages (new)
 
@@ -400,7 +400,7 @@ fn benchmark_works_with_init_args() {
 
 Benchmark: state_check
   total:
-    instructions: 804 (no change)
+    instructions: 867 (regressed by 7.84%)
     heap_increase: 0 pages (no change)
     stable_memory_increase: 0 pages (no change)
 
@@ -423,7 +423,7 @@ fn benchmark_stable_writes() {
 
 Benchmark: write_stable_memory (new)
   total:
-    instructions: 49.09 K (new)
+    instructions: 49.12 K (new)
     heap_increase: 0 pages (new)
     stable_memory_increase: 1 pages (new)
 

--- a/canbench-bin/tests/tests.rs
+++ b/canbench-bin/tests/tests.rs
@@ -400,7 +400,7 @@ fn benchmark_works_with_init_args() {
 
 Benchmark: state_check
   total:
-    instructions: 867 (regressed by 7.84%)
+    instructions: 930 (regressed by 15.67%)
     heap_increase: 0 pages (no change)
     stable_memory_increase: 0 pages (no change)
 

--- a/canbench-rs/src/lib.rs
+++ b/canbench-rs/src/lib.rs
@@ -409,7 +409,8 @@ use std::cell::RefCell;
 use std::collections::BTreeMap;
 
 thread_local! {
-    static SCOPES: RefCell<BTreeMap<&'static str, Measurement>> = RefCell::new(BTreeMap::new());
+    static SCOPES: RefCell<BTreeMap<&'static str, Measurement>> =
+        const { RefCell::new(BTreeMap::new()) };
 }
 
 /// The results of a benchmark.

--- a/examples/btreemap_vs_hashmap/canbench_results.yml
+++ b/examples/btreemap_vs_hashmap/canbench_results.yml
@@ -1,27 +1,27 @@
 benches:
   insert_users:
     total:
-      instructions: 2555314794
+      instructions: 2554172078
       heap_increase: 871
       stable_memory_increase: 0
     scopes: {}
   pre_upgrade_bench:
     total:
-      instructions: 787867913
+      instructions: 807868600
       heap_increase: 519
       stable_memory_increase: 184
     scopes:
       serialize_state:
-        instructions: 772935595
+        instructions: 792936247
         heap_increase: 519
         stable_memory_increase: 0
       writing_to_stable_memory:
-        instructions: 14930478
+        instructions: 14930479
         heap_increase: 0
         stable_memory_increase: 184
   remove_users:
     total:
-      instructions: 2095990298
+      instructions: 2109060905
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}

--- a/examples/btreemap_vs_hashmap/canbench_results.yml
+++ b/examples/btreemap_vs_hashmap/canbench_results.yml
@@ -1,28 +1,28 @@
 benches:
   insert_users:
     total:
-      instructions: 2570835903
+      instructions: 2555314794
       heap_increase: 871
       stable_memory_increase: 0
     scopes: {}
   pre_upgrade_bench:
     total:
-      instructions: 743977526
+      instructions: 787867913
       heap_increase: 519
       stable_memory_increase: 184
     scopes:
       serialize_state:
-        instructions: 729045047
+        instructions: 772935595
         heap_increase: 519
         stable_memory_increase: 0
       writing_to_stable_memory:
-        instructions: 14930540
+        instructions: 14930478
         heap_increase: 0
         stable_memory_increase: 184
   remove_users:
     total:
-      instructions: 2072135114
+      instructions: 2095990298
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
-version: 0.1.5
+version: 0.1.9

--- a/examples/fibonacci/canbench_results.yml
+++ b/examples/fibonacci/canbench_results.yml
@@ -1,14 +1,14 @@
 benches:
   fibonacci_20:
     total:
-      instructions: 2224
+      instructions: 2538
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   fibonacci_45:
     total:
-      instructions: 3011
+      instructions: 3331
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
-version: 0.1.1
+version: 0.1.9

--- a/examples/fibonacci/canbench_results.yml
+++ b/examples/fibonacci/canbench_results.yml
@@ -1,13 +1,13 @@
 benches:
   fibonacci_20:
     total:
-      instructions: 2538
+      instructions: 2187
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   fibonacci_45:
     total:
-      instructions: 3331
+      instructions: 2925
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.81.0"  # NOTE: remember to update CI as well.
+channel = "1.84.0"  # NOTE: remember to update CI as well.
 targets = ["wasm32-unknown-unknown"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.75.0"  # NOTE: remember to update CI as well.
+channel = "1.81.0"  # NOTE: remember to update CI as well.
 targets = ["wasm32-unknown-unknown"]

--- a/tests/init_arg/canbench_results.yml
+++ b/tests/init_arg/canbench_results.yml
@@ -1,9 +1,8 @@
-# The results in this file are artificial and are designed to trigger
-# certain scenarios.
 benches:
   state_check:
     total:
-      heap_delta: 0
-      instructions: 804
-      stable_memory_delta: 0
-version: 0.1.0
+      instructions: 867
+      heap_increase: 0
+      stable_memory_increase: 0
+    scopes: {}
+version: 0.1.9

--- a/tests/init_arg/canbench_results.yml
+++ b/tests/init_arg/canbench_results.yml
@@ -1,7 +1,7 @@
 benches:
   state_check:
     total:
-      instructions: 867
+      instructions: 872
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}

--- a/tests/init_arg/src/main.rs
+++ b/tests/init_arg/src/main.rs
@@ -2,7 +2,7 @@ use canbench_rs::bench;
 use std::cell::RefCell;
 
 thread_local! {
-    static STATE: RefCell<String> = RefCell::new(String::new());
+    static STATE: RefCell<String> = const { RefCell::new(String::new()) };
 }
 // A benchmark that prints the state.
 #[bench]


### PR DESCRIPTION
The upgrade is required by the https://github.com/dfinity/stable-structures/pull/267