### PR TITLE
refactor: Print all benchmark results at the end

### DIFF
--- a/canbench-bin/src/instruction_tracing.rs
+++ b/canbench-bin/src/instruction_tracing.rs
@@ -375,7 +375,6 @@ pub(super) fn write_traces_to_file(
     let reader = std::io::Cursor::new(logs);
     let mut writer = std::fs::File::create(&filename).map_err(|e| e.to_string())?;
     from_reader(&mut opt, reader, &mut writer).map_err(|e| e.to_string())?;
-    println!("Instruction traces written to {}", filename.display());
     Ok(())
 }
 

--- a/canbench-bin/src/lib.rs
+++ b/canbench-bin/src/lib.rs
@@ -93,8 +93,8 @@ pub fn run_benchmarks(
 
         let result = run_benchmark(&pocket_ic, benchmark_canister_id, bench_fn);
 
-        let filename = instruction_tracing_canister_id
-            .map(|instruction_tracing_canister_id| {
+        let filename =
+            instruction_tracing_canister_id.and_then(|instruction_tracing_canister_id| {
                 run_instruction_tracing(
                     &pocket_ic,
                     instruction_tracing_canister_id,
@@ -103,8 +103,7 @@ pub fn run_benchmarks(
                     results_file,
                     result.total.instructions,
                 )
-            })
-            .flatten();
+            });
 
         results.insert(bench_fn.to_string(), (result, filename));
         num_executed_bench_fns += 1;

--- a/canbench-bin/src/print_benchmark.rs
+++ b/canbench-bin/src/print_benchmark.rs
@@ -43,9 +43,9 @@ pub(crate) fn print_benchmark_results(
         }
 
         // Print instructions trace filename if available.
-        instructions_trace_filename.as_ref().map(|filename| {
+        if let Some(filename) = instructions_trace_filename {
             println!("Instruction traces written to {}", filename);
-        });
+        };
     }
 
     println!();


### PR DESCRIPTION
This restructures how benchmarks are printed from canbench to allow future improvements (for example printing benchmarks by categories of "improved"/"regressed" instead of a sequential list of them).

The change moves all logic related to printing benchmarks in a single function that can be called after benchmarks have been run instead of printing the results of each benchmark immediately. Hiding this behind a function allows more flexibility in how the results are presented (we can skip whatever was not changed, we can apply some aggregates for more concise output) to increase their usefulness.

There are no functional changes for now, only restructuring the code to allow further improvements in follow up PRs.