### PR TITLE
feat: add CSV reporting support

### DIFF
--- a/canbench-bin/src/csv_file.rs
+++ b/canbench-bin/src/csv_file.rs
@@ -13,29 +13,29 @@ pub(crate) fn write(
     let mut file = File::create(results_file)
         .unwrap_or_else(|e| panic!("Failed to create results file {:?}: {}", results_file, e));
 
-    writeln!(
-        file,
-        "status{dp}name{dp}instructions{dp}instructions %{dp}heap_increase{dp}heap_increase %{dp}stable_memory_increase{dp}stable_memory_increase %",
-        dp=DELIMITER
-    ).expect("Failed to write CSV header");
+    let headers = [
+        "status",
+        "name",
+        "instructions",
+        "instructions %",
+        "heap_increase",
+        "heap_increase %",
+        "stable_memory_increase",
+        "stable_memory_increase %",
+    ];
+    writeln!(file, "{}", headers.join(&DELIMITER.to_string())).expect("Failed to write CSV header");
 
     for (name, new_bench) in new_results {
         let old_bench = old_results.get(name);
-
-        write_measurement_diff(
-            &mut file,
-            if old_bench.is_some() { "" } else { "new" },
-            name,
-            &new_bench.total,
-            old_bench.map(|b| &b.total),
-            DELIMITER,
-        );
+        let status = if old_bench.is_some() { "" } else { "new" };
+        let old = old_bench.map(|b| &b.total);
+        write_measurement_diff(&mut file, status, name, &new_bench.total, old, DELIMITER);
     }
 }
 
 fn write_measurement_diff(
     file: &mut File,
-    new: &str,
+    status: &str,
     name: &str,
     new_m: &Measurement,
     old_m: Option<&Measurement>,
@@ -52,8 +52,8 @@ fn write_measurement_diff(
 
     writeln!(
         file,
-        "{new}{d}{name}{d}{ins}{d}{ins_p}{d}{heap}{d}{heap_p}{d}{smi}{d}{smi_p}",
-        new = new,
+        "{status}{d}{name}{d}{ins}{d}{ins_p}{d}{heap}{d}{heap_p}{d}{smi}{d}{smi_p}",
+        status = status,
         name = name,
         ins = new_m.instructions,
         ins_p = instr_pct,

--- a/canbench-bin/src/csv_file.rs
+++ b/canbench-bin/src/csv_file.rs
@@ -1,0 +1,73 @@
+use canbench_rs::{BenchResult, Measurement};
+use std::{collections::BTreeMap, fs::File, io::Write, path::PathBuf};
+
+/// Write benchmark results to CSV file.
+pub(crate) fn write(
+    results_file: &PathBuf,
+    new_results: &BTreeMap<String, BenchResult>,
+    old_results: &BTreeMap<String, BenchResult>,
+    delimiter: char,
+) {
+    let mut file = File::create(results_file)
+        .unwrap_or_else(|e| panic!("Failed to create results file {:?}: {}", results_file, e));
+
+    writeln!(
+        file,
+        "new{dp}name{dp}instructions{dp}instructions %{dp}heap_increase{dp}heap_increase %{dp}stable_memory_increase{dp}stable_memory_increase %",
+        dp=delimiter
+    ).expect("Failed to write CSV header");
+
+    for (name, new_bench) in new_results {
+        let old_bench = old_results.get(name);
+
+        write_measurement_diff(
+            &mut file,
+            if old_bench.is_some() { "old" } else { "new" },
+            name,
+            &new_bench.total,
+            old_bench.map(|b| &b.total),
+            delimiter,
+        );
+    }
+}
+
+fn write_measurement_diff(
+    file: &mut File,
+    new: &str,
+    name: &str,
+    new_m: &Measurement,
+    old_m: Option<&Measurement>,
+    delimiter: char,
+) {
+    let (instr_pct, heap_pct, stable_pct) = match old_m {
+        Some(old) => (
+            percent_diff(new_m.instructions, old.instructions),
+            percent_diff(new_m.heap_increase, old.heap_increase),
+            percent_diff(new_m.stable_memory_increase, old.stable_memory_increase),
+        ),
+        None => (String::new(), String::new(), String::new()),
+    };
+
+    writeln!(
+        file,
+        "{new}{d}{name}{d}{ins}{d}{ins_p}{d}{heap}{d}{heap_p}{d}{smi}{d}{smi_p}",
+        new = new,
+        name = name,
+        ins = new_m.instructions,
+        ins_p = instr_pct,
+        heap = new_m.heap_increase,
+        heap_p = heap_pct,
+        smi = new_m.stable_memory_increase,
+        smi_p = stable_pct,
+        d = delimiter
+    )
+    .unwrap_or_else(|e| panic!("Failed to write row for {}: {}", name, e));
+}
+
+fn percent_diff(new: u64, old: u64) -> String {
+    if old == 0 {
+        return String::new();
+    }
+    let diff = (new as f64 - old as f64) / old as f64 * 100.0;
+    format!("{:.2}%", diff)
+}

--- a/canbench-bin/src/csv_file.rs
+++ b/canbench-bin/src/csv_file.rs
@@ -13,7 +13,7 @@ pub(crate) fn write(
 
     writeln!(
         file,
-        "new{dp}name{dp}instructions{dp}instructions %{dp}heap_increase{dp}heap_increase %{dp}stable_memory_increase{dp}stable_memory_increase %",
+        "status{dp}name{dp}instructions{dp}instructions %{dp}heap_increase{dp}heap_increase %{dp}stable_memory_increase{dp}stable_memory_increase %",
         dp=delimiter
     ).expect("Failed to write CSV header");
 
@@ -22,7 +22,7 @@ pub(crate) fn write(
 
         write_measurement_diff(
             &mut file,
-            if old_bench.is_some() { "old" } else { "new" },
+            if old_bench.is_some() { "" } else { "new" },
             name,
             &new_bench.total,
             old_bench.map(|b| &b.total),

--- a/canbench-bin/src/csv_file.rs
+++ b/canbench-bin/src/csv_file.rs
@@ -1,12 +1,14 @@
 use canbench_rs::{BenchResult, Measurement};
 use std::{collections::BTreeMap, fs::File, io::Write, path::PathBuf};
 
+/// Delimiter used in the CSV file.
+const DELIMITER: char = '\t';
+
 /// Write benchmark results to CSV file.
 pub(crate) fn write(
     results_file: &PathBuf,
     new_results: &BTreeMap<String, BenchResult>,
     old_results: &BTreeMap<String, BenchResult>,
-    delimiter: char,
 ) {
     let mut file = File::create(results_file)
         .unwrap_or_else(|e| panic!("Failed to create results file {:?}: {}", results_file, e));
@@ -14,7 +16,7 @@ pub(crate) fn write(
     writeln!(
         file,
         "status{dp}name{dp}instructions{dp}instructions %{dp}heap_increase{dp}heap_increase %{dp}stable_memory_increase{dp}stable_memory_increase %",
-        dp=delimiter
+        dp=DELIMITER
     ).expect("Failed to write CSV header");
 
     for (name, new_bench) in new_results {
@@ -26,7 +28,7 @@ pub(crate) fn write(
             name,
             &new_bench.total,
             old_bench.map(|b| &b.total),
-            delimiter,
+            DELIMITER,
         );
     }
 }

--- a/canbench-bin/src/csv_file.rs
+++ b/canbench-bin/src/csv_file.rs
@@ -7,12 +7,12 @@ const DELIMITER: char = '\t';
 
 /// Write benchmark results to a CSV file.
 pub(crate) fn write(
-    results_file: &PathBuf,
+    output_file: &PathBuf,
     new_results: &BTreeMap<String, BenchResult>,
     old_results: &BTreeMap<String, BenchResult>,
 ) {
-    let mut file = File::create(results_file)
-        .unwrap_or_else(|e| panic!("Failed to create results file {:?}: {}", results_file, e));
+    let mut file = File::create(output_file)
+        .unwrap_or_else(|e| panic!("Failed to create results file {:?}: {}", output_file, e));
 
     let headers = [
         "status",

--- a/canbench-bin/src/csv_file.rs
+++ b/canbench-bin/src/csv_file.rs
@@ -2,6 +2,7 @@ use canbench_rs::{BenchResult, Measurement};
 use std::{collections::BTreeMap, fs::File, io::Write, path::PathBuf};
 
 /// Delimiter used in the CSV file.
+/// Tab `\t` avoids issues with commas in numbers or text and is reliably parsed by Google Sheets.
 const DELIMITER: char = '\t';
 
 /// Write benchmark results to a CSV file.

--- a/canbench-bin/src/lib.rs
+++ b/canbench-bin/src/lib.rs
@@ -145,7 +145,7 @@ pub fn run_benchmarks(
     }
 
     if csv {
-        csv_file::write(csv_results_file, &new_results, &old_results, '\t');
+        csv_file::write(csv_results_file, &new_results, &old_results);
         println!(
             "Successfully saved CSV results to {}",
             csv_results_file.display()

--- a/canbench-bin/src/lib.rs
+++ b/canbench-bin/src/lib.rs
@@ -1,4 +1,5 @@
 //! A module for running benchmarks.
+mod csv_file;
 mod instruction_tracing;
 mod print_benchmark;
 mod results_file;
@@ -39,6 +40,8 @@ pub fn run_benchmarks(
     init_args: Vec<u8>,
     persist: bool,
     results_file: &PathBuf,
+    csv: bool,
+    csv_results_file: &PathBuf,
     verbose: bool,
     show_results: bool,
     show_summary: bool,
@@ -134,10 +137,18 @@ pub fn run_benchmarks(
 
     // Persist the result if requested.
     if persist {
-        results_file::write(results_file, new_results);
+        results_file::write(results_file, new_results.clone());
         println!(
             "Successfully persisted results to {}",
             results_file.display()
+        );
+    }
+
+    if csv {
+        csv_file::write(csv_results_file, &new_results, &old_results, ';');
+        println!(
+            "Successfully saved CSV results to {}",
+            csv_results_file.display()
         );
     }
 }

--- a/canbench-bin/src/lib.rs
+++ b/canbench-bin/src/lib.rs
@@ -145,7 +145,7 @@ pub fn run_benchmarks(
     }
 
     if csv {
-        csv_file::write(csv_results_file, &new_results, &old_results, ';');
+        csv_file::write(csv_results_file, &new_results, &old_results, '\t');
         println!(
             "Successfully saved CSV results to {}",
             csv_results_file.display()

--- a/canbench-bin/src/lib.rs
+++ b/canbench-bin/src/lib.rs
@@ -136,16 +136,16 @@ pub fn run_benchmarks(
 
     // Persist the result if requested.
     if persist {
-        results_file::write(results_file, new_results.clone());
-        println!(
-            "Successfully persisted results to {}",
-            results_file.display()
-        );
-
         csv_file::write(csv_results_file, &new_results, &old_results);
         println!(
             "Successfully saved CSV results to {}",
             csv_results_file.display()
+        );
+
+        results_file::write(results_file, new_results);
+        println!(
+            "Successfully persisted results to {}",
+            results_file.display()
         );
     }
 }

--- a/canbench-bin/src/lib.rs
+++ b/canbench-bin/src/lib.rs
@@ -40,7 +40,6 @@ pub fn run_benchmarks(
     init_args: Vec<u8>,
     persist: bool,
     results_file: &PathBuf,
-    csv: bool,
     csv_results_file: &PathBuf,
     verbose: bool,
     show_results: bool,
@@ -142,9 +141,7 @@ pub fn run_benchmarks(
             "Successfully persisted results to {}",
             results_file.display()
         );
-    }
 
-    if csv {
         csv_file::write(csv_results_file, &new_results, &old_results);
         println!(
             "Successfully saved CSV results to {}",

--- a/canbench-bin/src/main.rs
+++ b/canbench-bin/src/main.rs
@@ -6,6 +6,7 @@ use std::{fs::File, io::Read, path::PathBuf, process::Command};
 
 const CFG_FILE_NAME: &str = "canbench.yml";
 const DEFAULT_RESULTS_FILE: &str = "canbench_results.yml";
+const DEFAULT_CSV_RESULTS_FILE: &str = "canbench_results.csv";
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -16,6 +17,10 @@ struct Args {
     /// Whether or not results should be persisted to disk.
     #[clap(long)]
     persist: bool,
+
+    /// Whether or not results should be written to CSV.
+    #[clap(long)]
+    csv: bool,
 
     /// Only print the benchmark results (and nothing else).
     #[clap(long)]
@@ -83,6 +88,10 @@ struct Config {
     // Otherwise, `canbench_results.yml` is used by default
     results_path: Option<String>,
 
+    // If provided, instructs canbench to store the results in this CSV file
+    // Otherwise, `canbench_results.csv` is used by default
+    csv_results_path: Option<String>,
+
     // If provided, the init arguments to pass to the canister
     init_args: Option<InitArgs>,
 
@@ -130,6 +139,11 @@ fn main() {
             .as_ref()
             .unwrap_or(&DEFAULT_RESULTS_FILE.to_string()),
     );
+    let csv_results_path = PathBuf::from(
+        cfg.csv_results_path
+            .as_ref()
+            .unwrap_or(&DEFAULT_CSV_RESULTS_FILE.to_string()),
+    );
 
     // Build the canister if a build command is specified.
     if let Some(build_cmd) = cfg.build_cmd {
@@ -158,6 +172,8 @@ fn main() {
         init_args,
         args.persist,
         &results_path,
+        args.csv,
+        &csv_results_path,
         !args.less_verbose,
         !args.hide_results,
         args.show_summary,

--- a/canbench-bin/src/main.rs
+++ b/canbench-bin/src/main.rs
@@ -18,10 +18,6 @@ struct Args {
     #[clap(long)]
     persist: bool,
 
-    /// Write results to a CSV file.
-    #[clap(long)]
-    csv: bool,
-
     /// Only print the benchmark results (and nothing else).
     #[clap(long)]
     less_verbose: bool,
@@ -172,7 +168,6 @@ fn main() {
         init_args,
         args.persist,
         &results_path,
-        args.csv,
         &csv_results_path,
         !args.less_verbose,
         !args.hide_results,

--- a/canbench-bin/src/main.rs
+++ b/canbench-bin/src/main.rs
@@ -18,7 +18,7 @@ struct Args {
     #[clap(long)]
     persist: bool,
 
-    /// Whether or not results should be written to CSV.
+    /// Write results to a CSV file.
     #[clap(long)]
     csv: bool,
 

--- a/canbench-rs/src/lib.rs
+++ b/canbench-rs/src/lib.rs
@@ -473,7 +473,7 @@ thread_local! {
 }
 
 /// The results of a benchmark.
-#[derive(Debug, PartialEq, Serialize, Deserialize, CandidType, Default)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, CandidType, Default, Clone)]
 pub struct BenchResult {
     /// A measurement for the entire duration of the benchmark.
     pub total: Measurement,

--- a/canbench-rs/src/lib.rs
+++ b/canbench-rs/src/lib.rs
@@ -473,7 +473,7 @@ thread_local! {
 }
 
 /// The results of a benchmark.
-#[derive(Debug, PartialEq, Serialize, Deserialize, CandidType, Default, Clone)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, CandidType, Default)]
 pub struct BenchResult {
     /// A measurement for the entire duration of the benchmark.
     pub total: Measurement,

--- a/examples/btreemap_vs_hashmap/canbench_results.csv
+++ b/examples/btreemap_vs_hashmap/canbench_results.csv
@@ -1,4 +1,4 @@
-new	name	instructions	instructions %	heap_increase	heap_increase %	stable_memory_increase	stable_memory_increase %
-old	insert_users	2558172740	0.00%	872	0.00%	0	
-old	pre_upgrade_bench	438878782	0.00%	519	0.00%	184	0.00%
-old	remove_users	2109060849	0.00%	0		0	
+status	name	instructions	instructions %	heap_increase	heap_increase %	stable_memory_increase	stable_memory_increase %
+	insert_users	2558172740	0.00%	872	0.00%	0	
+	pre_upgrade_bench	438878782	0.00%	519	0.00%	184	0.00%
+	remove_users	2109060849	0.00%	0		0	

--- a/examples/btreemap_vs_hashmap/canbench_results.csv
+++ b/examples/btreemap_vs_hashmap/canbench_results.csv
@@ -1,0 +1,4 @@
+new	name	instructions	instructions %	heap_increase	heap_increase %	stable_memory_increase	stable_memory_increase %
+old	insert_users	2558172740	0.00%	872	0.00%	0	
+old	pre_upgrade_bench	438878782	0.00%	519	0.00%	184	0.00%
+old	remove_users	2109060849	0.00%	0		0	

--- a/examples/btreemap_vs_hashmap/canbench_results.yml
+++ b/examples/btreemap_vs_hashmap/canbench_results.yml
@@ -7,7 +7,7 @@ benches:
     scopes: {}
   pre_upgrade_bench:
     total:
-      instructions: 438878344
+      instructions: 438878782
       heap_increase: 519
       stable_memory_increase: 184
     scopes:

--- a/examples/fibonacci/canbench_results.csv
+++ b/examples/fibonacci/canbench_results.csv
@@ -1,0 +1,6 @@
+new	name	instructions	instructions %	heap_increase	heap_increase %	stable_memory_increase	stable_memory_increase %
+old	fibonacci_20	726	0.00%	0		0	
+old	fibonacci_45	1301	0.00%	0		0	
+old	fibonacci_8a	450	0.00%	0		0	
+old	fibonacci_8b	207	0.00%	0		0	
+old	fibonacci_8c	391	0.00%	0		0	

--- a/examples/fibonacci/canbench_results.csv
+++ b/examples/fibonacci/canbench_results.csv
@@ -1,6 +1,6 @@
-new	name	instructions	instructions %	heap_increase	heap_increase %	stable_memory_increase	stable_memory_increase %
-old	fibonacci_20	726	0.00%	0		0	
-old	fibonacci_45	1301	0.00%	0		0	
-old	fibonacci_8a	450	0.00%	0		0	
-old	fibonacci_8b	207	0.00%	0		0	
-old	fibonacci_8c	391	0.00%	0		0	
+status	name	instructions	instructions %	heap_increase	heap_increase %	stable_memory_increase	stable_memory_increase %
+	fibonacci_20	726	0.00%	0		0	
+	fibonacci_45	1301	0.00%	0		0	
+	fibonacci_8a	450	0.00%	0		0	
+	fibonacci_8b	207	0.00%	0		0	
+	fibonacci_8c	391	0.00%	0		0	

--- a/examples/fibonacci/canbench_results.yml
+++ b/examples/fibonacci/canbench_results.yml
@@ -1,19 +1,19 @@
 benches:
   fibonacci_20:
     total:
-      instructions: 730
+      instructions: 726
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   fibonacci_45:
     total:
-      instructions: 1305
+      instructions: 1301
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   fibonacci_8a:
     total:
-      instructions: 454
+      instructions: 450
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
@@ -25,7 +25,7 @@ benches:
     scopes: {}
   fibonacci_8c:
     total:
-      instructions: 395
+      instructions: 391
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}


### PR DESCRIPTION
Add CSV export with `--persist` flag for easier benchmark analysis.

This PR enables writing benchmark results to a CSV file when the `--persist` flag is used.
It helps improve readability and analysis of large benchmark sets by allowing results to be inspected in spreadsheet software.