### PR TITLE
feat: control CSV reporting via --csv flag

### DIFF
--- a/canbench-bin/src/lib.rs
+++ b/canbench-bin/src/lib.rs
@@ -39,6 +39,7 @@ pub fn run_benchmarks(
     pattern: Option<String>,
     init_args: Vec<u8>,
     persist: bool,
+    csv: bool,
     results_file: &PathBuf,
     csv_results_file: &PathBuf,
     verbose: bool,
@@ -134,14 +135,16 @@ pub fn run_benchmarks(
         println!("---------------------------------------------------");
     }
 
-    // Persist the result if requested.
-    if persist {
+    if csv {
         csv_file::write(csv_results_file, &new_results, &old_results);
         println!(
             "Successfully saved CSV results to {}",
             csv_results_file.display()
         );
+    }
 
+    // Persist the result if requested.
+    if persist {
         results_file::write(results_file, new_results);
         println!(
             "Successfully persisted results to {}",

--- a/canbench-bin/src/lib.rs
+++ b/canbench-bin/src/lib.rs
@@ -135,6 +135,7 @@ pub fn run_benchmarks(
         println!("---------------------------------------------------");
     }
 
+    // Save benchmark results in CSV format if requested.
     if csv {
         csv_file::write(csv_results_file, &new_results, &old_results);
         println!(

--- a/canbench-bin/src/main.rs
+++ b/canbench-bin/src/main.rs
@@ -18,6 +18,10 @@ struct Args {
     #[clap(long)]
     persist: bool,
 
+    /// Write results to a CSV file.
+    #[clap(long)]
+    csv: bool,
+
     /// Only print the benchmark results (and nothing else).
     #[clap(long)]
     less_verbose: bool,
@@ -167,6 +171,7 @@ fn main() {
         args.pattern,
         init_args,
         args.persist,
+        args.csv,
         &results_path,
         &csv_results_path,
         !args.less_verbose,


### PR DESCRIPTION
Decouple CSV reporting from `--persist` and introduce `--csv` flag.

This change ensures that `--persist` behaves as before, updating only `canbench_results.yml` without generating additional files. CSV reporting is now controlled separately via the new `--csv` flag, allowing clearer intent and cleaner output management.







