### PR TITLE
feat: improve summary output with separate counters and clearer formatting

### DIFF
--- a/canbench-bin/src/summary.rs
+++ b/canbench-bin/src/summary.rs
@@ -77,9 +77,15 @@ fn print_metric_summary<F>(
     debug_assert_eq!(total, new_results.len(), "total count mismatch");
 
     println!("  {label}:");
+    let emoji_status = match (improved, regressed) {
+        (0, 0) => "",
+        (_, 0) => " 🟢",
+        (0, _) => " 🔴",
+        _ => " 🟢🔴",
+    };
     println!(
-        "    counts    : [total {} | new {} | improved {} | regressed {} | unchanged {}]",
-        total, new_only, improved, regressed, unchanged
+        "    counts    : [total {} | new {} | improved {} | regressed {} | unchanged {}]{}",
+        total, new_only, improved, regressed, unchanged, emoji_status
     );
 
     if !abs_deltas.is_empty() {

--- a/canbench-bin/src/summary.rs
+++ b/canbench-bin/src/summary.rs
@@ -78,10 +78,10 @@ fn print_metric_summary<F>(
 
     println!("  {label}:");
     let emoji_status = match (improved, regressed) {
-        (0, 0) => "",
-        (_, 0) => " 🟢",
-        (0, _) => " 🔴",
-        _ => " 🟢🔴",
+        (0, 0) => "",    // No changes
+        (0, _) => " 🔴", // Only regressions
+        (_, 0) => " 🟢", // Only improvements
+        _ => " 🟢🔴",    // Both improvements and regressions
     };
     println!(
         "    counts:   [total {} | new {} | improved {} | regressed {} | unchanged {}]{}",

--- a/canbench-bin/src/summary.rs
+++ b/canbench-bin/src/summary.rs
@@ -78,7 +78,7 @@ fn print_metric_summary<F>(
 
     println!("  {label}:");
     let emoji_status = match (improved, regressed) {
-        (0, 0) => "",    // No changes
+        (0, 0) => "",    // No improvements or regressions
         (0, _) => " 🔴", // Only regressions
         (_, 0) => " 🟢", // Only improvements
         _ => " 🟢🔴",    // Both improvements and regressions

--- a/canbench-bin/src/summary.rs
+++ b/canbench-bin/src/summary.rs
@@ -79,8 +79,8 @@ fn print_metric_summary<F>(
     println!("  {label}:");
     let emoji_status = match (improved, regressed) {
         (0, 0) => "",    // No improvements or regressions
-        (0, _) => " 🔴", // Only regressions
         (_, 0) => " 🟢", // Only improvements
+        (0, _) => " 🔴", // Only regressions
         _ => " 🟢🔴",    // Both improvements and regressions
     };
     println!(

--- a/canbench-bin/src/summary.rs
+++ b/canbench-bin/src/summary.rs
@@ -77,18 +77,26 @@ fn print_metric_summary<F>(
     debug_assert_eq!(total, new_results.len(), "total count mismatch");
 
     println!("  {label}:");
-    println!("    improved: {improved}, regressed: {regressed}, unchanged: {unchanged}, new: {new_only}, total: {total}");
+    println!(
+        "    counts    : [total {} | new {} | improved {} | regressed {} | unchanged {}]",
+        total, new_only, improved, regressed, unchanged
+    );
 
     if !abs_deltas.is_empty() {
-        print_range("    change   ", &abs_deltas, fmt_human, percentile_i64);
+        print_range("    change    ", &abs_deltas, fmt_human, percentile_i64);
     } else {
-        println!("    change   : n/a");
+        println!("    change    : n/a");
     }
 
     if !percent_diffs.is_empty() {
-        print_range("    change % ", &percent_diffs, fmt_percent, percentile_f64);
+        print_range(
+            "    change %  ",
+            &percent_diffs,
+            fmt_percent,
+            percentile_f64,
+        );
     } else {
-        println!("    change % : n/a");
+        println!("    change %  : n/a");
     }
 }
 

--- a/canbench-bin/src/summary.rs
+++ b/canbench-bin/src/summary.rs
@@ -84,29 +84,24 @@ fn print_metric_summary<F>(
         _ => " 🟢🔴",
     };
     println!(
-        "    counts    : [total {} | new {} | improved {} | regressed {} | unchanged {}]{}",
+        "    counts:   [total {} | new {} | improved {} | regressed {} | unchanged {}]{}",
         total, new_only, improved, regressed, unchanged, emoji_status
     );
 
     if !abs_deltas.is_empty() {
-        print_range("    change    ", &abs_deltas, fmt_human, percentile_i64);
+        print_range("    change:  ", &abs_deltas, fmt_human, percentile_i64);
     } else {
-        println!("    change    : n/a");
+        println!("    change:   n/a");
     }
 
     if !percent_diffs.is_empty() {
-        print_range(
-            "    change %  ",
-            &percent_diffs,
-            fmt_percent,
-            percentile_f64,
-        );
+        print_range("    change %:", &percent_diffs, fmt_percent, percentile_f64);
     } else {
-        println!("    change %  : n/a");
+        println!("    change %: n/a");
     }
 }
 
-fn print_range<T, F, P>(label: &str, values: &[T], format: F, percentile_fn: P)
+fn print_range<T, F, P>(prefix: &str, values: &[T], format: F, percentile_fn: P)
 where
     T: PartialOrd + Copy,
     F: Fn(T) -> String,
@@ -119,7 +114,7 @@ where
     let max = sorted.last().copied().unwrap();
 
     println!(
-        "{label}: [min {} | med {} | max {}]",
+        "{prefix} [min {} | med {} | max {}]",
         format(min),
         format(med),
         format(max),

--- a/canbench-bin/tests/tests.rs
+++ b/canbench-bin/tests/tests.rs
@@ -44,19 +44,19 @@ Benchmark: no_changes_test
 
 Summary:
   instructions:
-    improved: 0, regressed: 0, unchanged: 1, new: 0, total: 1
-    change   : [min 0 | med 0 | max 0]
-    change % : [min 0% | med 0% | max 0%]
+    counts    : [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
+    change    : [min 0 | med 0 | max 0]
+    change %  : [min 0% | med 0% | max 0%]
 
   heap_increase:
-    improved: 0, regressed: 0, unchanged: 1, new: 0, total: 1
-    change   : [min 0 | med 0 | max 0]
-    change % : [min 0% | med 0% | max 0%]
+    counts    : [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
+    change    : [min 0 | med 0 | max 0]
+    change %  : [min 0% | med 0% | max 0%]
 
   stable_memory_increase:
-    improved: 0, regressed: 0, unchanged: 1, new: 0, total: 1
-    change   : [min 0 | med 0 | max 0]
-    change % : [min 0% | med 0% | max 0%]
+    counts    : [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
+    change    : [min 0 | med 0 | max 0]
+    change %  : [min 0% | med 0% | max 0%]
 
 ---------------------------------------------------
 "
@@ -77,19 +77,19 @@ fn benchmark_reports_no_changes_with_hide_results() {
 
 Summary:
   instructions:
-    improved: 0, regressed: 0, unchanged: 1, new: 0, total: 1
-    change   : [min 0 | med 0 | max 0]
-    change % : [min 0% | med 0% | max 0%]
+    counts    : [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
+    change    : [min 0 | med 0 | max 0]
+    change %  : [min 0% | med 0% | max 0%]
 
   heap_increase:
-    improved: 0, regressed: 0, unchanged: 1, new: 0, total: 1
-    change   : [min 0 | med 0 | max 0]
-    change % : [min 0% | med 0% | max 0%]
+    counts    : [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
+    change    : [min 0 | med 0 | max 0]
+    change %  : [min 0% | med 0% | max 0%]
 
   stable_memory_increase:
-    improved: 0, regressed: 0, unchanged: 1, new: 0, total: 1
-    change   : [min 0 | med 0 | max 0]
-    change % : [min 0% | med 0% | max 0%]
+    counts    : [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
+    change    : [min 0 | med 0 | max 0]
+    change %  : [min 0% | med 0% | max 0%]
 
 ---------------------------------------------------
 "
@@ -131,19 +131,19 @@ Benchmark: noisy_change_test
 
 Summary:
   instructions:
-    improved: 0, regressed: 0, unchanged: 1, new: 0, total: 1
-    change   : [min -3 | med -3 | max -3]
-    change % : [min -1.43% | med -1.43% | max -1.43%]
+    counts    : [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
+    change    : [min -3 | med -3 | max -3]
+    change %  : [min -1.43% | med -1.43% | max -1.43%]
 
   heap_increase:
-    improved: 0, regressed: 0, unchanged: 1, new: 0, total: 1
-    change   : [min 0 | med 0 | max 0]
-    change % : [min 0% | med 0% | max 0%]
+    counts    : [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
+    change    : [min 0 | med 0 | max 0]
+    change %  : [min 0% | med 0% | max 0%]
 
   stable_memory_increase:
-    improved: 0, regressed: 0, unchanged: 1, new: 0, total: 1
-    change   : [min 0 | med 0 | max 0]
-    change % : [min 0% | med 0% | max 0%]
+    counts    : [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
+    change    : [min 0 | med 0 | max 0]
+    change %  : [min 0% | med 0% | max 0%]
 
 ---------------------------------------------------
 "
@@ -171,19 +171,19 @@ Benchmark: noisy_change_above_default_threshold_test
 
 Summary:
   instructions:
-    improved: 1, regressed: 0, unchanged: 0, new: 0, total: 1
-    change   : [min -154.07 K | med -154.07 K | max -154.07 K]
-    change % : [min -4.35% | med -4.35% | max -4.35%]
+    counts    : [total 1 | new 0 | improved 1 | regressed 0 | unchanged 0]
+    change    : [min -154.07 K | med -154.07 K | max -154.07 K]
+    change %  : [min -4.35% | med -4.35% | max -4.35%]
 
   heap_increase:
-    improved: 1, regressed: 0, unchanged: 0, new: 0, total: 1
-    change   : [min -3 | med -3 | max -3]
-    change % : [min -4.62% | med -4.62% | max -4.62%]
+    counts    : [total 1 | new 0 | improved 1 | regressed 0 | unchanged 0]
+    change    : [min -3 | med -3 | max -3]
+    change %  : [min -4.62% | med -4.62% | max -4.62%]
 
   stable_memory_increase:
-    improved: 1, regressed: 0, unchanged: 0, new: 0, total: 1
-    change   : [min -4 | med -4 | max -4]
-    change % : [min -3.85% | med -3.85% | max -3.85%]
+    counts    : [total 1 | new 0 | improved 1 | regressed 0 | unchanged 0]
+    change    : [min -4 | med -4 | max -4]
+    change %  : [min -3.85% | med -3.85% | max -3.85%]
 
 ---------------------------------------------------
 "
@@ -212,19 +212,19 @@ Benchmark: noisy_change_above_default_threshold_test
 
 Summary:
   instructions:
-    improved: 0, regressed: 0, unchanged: 1, new: 0, total: 1
-    change   : [min -154.07 K | med -154.07 K | max -154.07 K]
-    change % : [min -4.35% | med -4.35% | max -4.35%]
+    counts    : [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
+    change    : [min -154.07 K | med -154.07 K | max -154.07 K]
+    change %  : [min -4.35% | med -4.35% | max -4.35%]
 
   heap_increase:
-    improved: 0, regressed: 0, unchanged: 1, new: 0, total: 1
-    change   : [min -3 | med -3 | max -3]
-    change % : [min -4.62% | med -4.62% | max -4.62%]
+    counts    : [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
+    change    : [min -3 | med -3 | max -3]
+    change %  : [min -4.62% | med -4.62% | max -4.62%]
 
   stable_memory_increase:
-    improved: 0, regressed: 0, unchanged: 1, new: 0, total: 1
-    change   : [min -4 | med -4 | max -4]
-    change % : [min -3.85% | med -3.85% | max -3.85%]
+    counts    : [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
+    change    : [min -4 | med -4 | max -4]
+    change %  : [min -3.85% | med -3.85% | max -3.85%]
 
 ---------------------------------------------------
 "
@@ -252,19 +252,19 @@ Benchmark: regression_test
 
 Summary:
   instructions:
-    improved: 0, regressed: 1, unchanged: 0, new: 0, total: 1
-    change   : [min 197 | med 197 | max 197]
-    change % : [min +1970.00% | med +1970.00% | max +1970.00%]
+    counts    : [total 1 | new 0 | improved 0 | regressed 1 | unchanged 0]
+    change    : [min 197 | med 197 | max 197]
+    change %  : [min +1970.00% | med +1970.00% | max +1970.00%]
 
   heap_increase:
-    improved: 0, regressed: 0, unchanged: 1, new: 0, total: 1
-    change   : [min 0 | med 0 | max 0]
-    change % : [min 0% | med 0% | max 0%]
+    counts    : [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
+    change    : [min 0 | med 0 | max 0]
+    change %  : [min 0% | med 0% | max 0%]
 
   stable_memory_increase:
-    improved: 0, regressed: 0, unchanged: 1, new: 0, total: 1
-    change   : [min 0 | med 0 | max 0]
-    change % : [min 0% | med 0% | max 0%]
+    counts    : [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
+    change    : [min 0 | med 0 | max 0]
+    change %  : [min 0% | med 0% | max 0%]
 
 ---------------------------------------------------
 "
@@ -292,19 +292,19 @@ Benchmark: improvement_test
 
 Summary:
   instructions:
-    improved: 1, regressed: 0, unchanged: 0, new: 0, total: 1
-    change   : [min -2.89 K | med -2.89 K | max -2.89 K]
-    change % : [min -93.32% | med -93.32% | max -93.32%]
+    counts    : [total 1 | new 0 | improved 1 | regressed 0 | unchanged 0]
+    change    : [min -2.89 K | med -2.89 K | max -2.89 K]
+    change %  : [min -93.32% | med -93.32% | max -93.32%]
 
   heap_increase:
-    improved: 0, regressed: 0, unchanged: 1, new: 0, total: 1
-    change   : [min 0 | med 0 | max 0]
-    change % : [min 0% | med 0% | max 0%]
+    counts    : [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
+    change    : [min 0 | med 0 | max 0]
+    change %  : [min 0% | med 0% | max 0%]
 
   stable_memory_increase:
-    improved: 0, regressed: 0, unchanged: 1, new: 0, total: 1
-    change   : [min 0 | med 0 | max 0]
-    change % : [min 0% | med 0% | max 0%]
+    counts    : [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
+    change    : [min 0 | med 0 | max 0]
+    change %  : [min 0% | med 0% | max 0%]
 
 ---------------------------------------------------
 "
@@ -332,19 +332,19 @@ Benchmark: stable_memory_increase_from_zero
 
 Summary:
   instructions:
-    improved: 0, regressed: 1, unchanged: 0, new: 0, total: 1
-    change   : [min 307 | med 307 | max 307]
-    change % : n/a
+    counts    : [total 1 | new 0 | improved 0 | regressed 1 | unchanged 0]
+    change    : [min 307 | med 307 | max 307]
+    change %  : n/a
 
   heap_increase:
-    improved: 0, regressed: 0, unchanged: 1, new: 0, total: 1
-    change   : [min 0 | med 0 | max 0]
-    change % : [min 0% | med 0% | max 0%]
+    counts    : [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
+    change    : [min 0 | med 0 | max 0]
+    change %  : [min 0% | med 0% | max 0%]
 
   stable_memory_increase:
-    improved: 0, regressed: 1, unchanged: 0, new: 0, total: 1
-    change   : [min 123 | med 123 | max 123]
-    change % : n/a
+    counts    : [total 1 | new 0 | improved 0 | regressed 1 | unchanged 0]
+    change    : [min 123 | med 123 | max 123]
+    change %  : n/a
 
 ---------------------------------------------------
 "
@@ -374,19 +374,19 @@ Benchmark: stable_memory_only_increase (new)
 
 Summary:
   instructions:
-    improved: 0, regressed: 0, unchanged: 0, new: 1, total: 1
-    change   : [min 307 | med 307 | max 307]
-    change % : n/a
+    counts    : [total 1 | new 1 | improved 0 | regressed 0 | unchanged 0]
+    change    : [min 307 | med 307 | max 307]
+    change %  : n/a
 
   heap_increase:
-    improved: 0, regressed: 0, unchanged: 0, new: 1, total: 1
-    change   : [min 0 | med 0 | max 0]
-    change % : n/a
+    counts    : [total 1 | new 1 | improved 0 | regressed 0 | unchanged 0]
+    change    : [min 0 | med 0 | max 0]
+    change %  : n/a
 
   stable_memory_increase:
-    improved: 0, regressed: 0, unchanged: 0, new: 1, total: 1
-    change   : [min 456 | med 456 | max 456]
-    change % : n/a
+    counts    : [total 1 | new 1 | improved 0 | regressed 0 | unchanged 0]
+    change    : [min 456 | med 456 | max 456]
+    change %  : n/a
 
 ---------------------------------------------------
 "
@@ -414,19 +414,19 @@ Benchmark: increase_heap_increase (new)
 
 Summary:
   instructions:
-    improved: 0, regressed: 0, unchanged: 0, new: 1, total: 1
-    change   : [min 3.39 M | med 3.39 M | max 3.39 M]
-    change % : n/a
+    counts    : [total 1 | new 1 | improved 0 | regressed 0 | unchanged 0]
+    change    : [min 3.39 M | med 3.39 M | max 3.39 M]
+    change %  : n/a
 
   heap_increase:
-    improved: 0, regressed: 0, unchanged: 0, new: 1, total: 1
-    change   : [min 62 | med 62 | max 62]
-    change % : n/a
+    counts    : [total 1 | new 1 | improved 0 | regressed 0 | unchanged 0]
+    change    : [min 62 | med 62 | max 62]
+    change %  : n/a
 
   stable_memory_increase:
-    improved: 0, regressed: 0, unchanged: 0, new: 1, total: 1
-    change   : [min 0 | med 0 | max 0]
-    change % : n/a
+    counts    : [total 1 | new 1 | improved 0 | regressed 0 | unchanged 0]
+    change    : [min 0 | med 0 | max 0]
+    change %  : n/a
 
 ---------------------------------------------------
 "
@@ -460,19 +460,19 @@ Benchmark: bench_2 (new)
 
 Summary:
   instructions:
-    improved: 0, regressed: 0, unchanged: 0, new: 2, total: 2
-    change   : [min 207 | med 207 | max 207]
-    change % : n/a
+    counts    : [total 2 | new 2 | improved 0 | regressed 0 | unchanged 0]
+    change    : [min 207 | med 207 | max 207]
+    change %  : n/a
 
   heap_increase:
-    improved: 0, regressed: 0, unchanged: 0, new: 2, total: 2
-    change   : [min 0 | med 0 | max 0]
-    change % : n/a
+    counts    : [total 2 | new 2 | improved 0 | regressed 0 | unchanged 0]
+    change    : [min 0 | med 0 | max 0]
+    change %  : n/a
 
   stable_memory_increase:
-    improved: 0, regressed: 0, unchanged: 0, new: 2, total: 2
-    change   : [min 0 | med 0 | max 0]
-    change % : n/a
+    counts    : [total 2 | new 2 | improved 0 | regressed 0 | unchanged 0]
+    change    : [min 0 | med 0 | max 0]
+    change %  : n/a
 
 ---------------------------------------------------
 "
@@ -510,19 +510,19 @@ Benchmark: bench_scope_new (new)
 
 Summary:
   instructions:
-    improved: 0, regressed: 0, unchanged: 0, new: 1, total: 1
-    change   : [min 4.63 K | med 4.63 K | max 4.63 K]
-    change % : n/a
+    counts    : [total 1 | new 1 | improved 0 | regressed 0 | unchanged 0]
+    change    : [min 4.63 K | med 4.63 K | max 4.63 K]
+    change %  : n/a
 
   heap_increase:
-    improved: 0, regressed: 0, unchanged: 0, new: 1, total: 1
-    change   : [min 1 | med 1 | max 1]
-    change % : n/a
+    counts    : [total 1 | new 1 | improved 0 | regressed 0 | unchanged 0]
+    change    : [min 1 | med 1 | max 1]
+    change %  : n/a
 
   stable_memory_increase:
-    improved: 0, regressed: 0, unchanged: 0, new: 1, total: 1
-    change   : [min 0 | med 0 | max 0]
-    change % : n/a
+    counts    : [total 1 | new 1 | improved 0 | regressed 0 | unchanged 0]
+    change    : [min 0 | med 0 | max 0]
+    change %  : n/a
 
 ---------------------------------------------------
 "
@@ -605,19 +605,19 @@ Benchmark: bench_scope_exists
 
 Summary:
   instructions:
-    improved: 0, regressed: 1, unchanged: 0, new: 0, total: 1
-    change   : [min 4.63 K | med 4.63 K | max 4.63 K]
-    change % : n/a
+    counts    : [total 1 | new 0 | improved 0 | regressed 1 | unchanged 0]
+    change    : [min 4.63 K | med 4.63 K | max 4.63 K]
+    change %  : n/a
 
   heap_increase:
-    improved: 0, regressed: 1, unchanged: 0, new: 0, total: 1
-    change   : [min 1 | med 1 | max 1]
-    change % : n/a
+    counts    : [total 1 | new 0 | improved 0 | regressed 1 | unchanged 0]
+    change    : [min 1 | med 1 | max 1]
+    change %  : n/a
 
   stable_memory_increase:
-    improved: 0, regressed: 0, unchanged: 1, new: 0, total: 1
-    change   : [min 0 | med 0 | max 0]
-    change % : [min 0% | med 0% | max 0%]
+    counts    : [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
+    change    : [min 0 | med 0 | max 0]
+    change %  : [min 0% | med 0% | max 0%]
 
 ---------------------------------------------------
 "
@@ -657,19 +657,19 @@ Benchmark: state_check
 
 Summary:
   instructions:
-    improved: 0, regressed: 1, unchanged: 0, new: 0, total: 1
-    change   : [min 31 | med 31 | max 31]
-    change % : [min +3.69% | med +3.69% | max +3.69%]
+    counts    : [total 1 | new 0 | improved 0 | regressed 1 | unchanged 0]
+    change    : [min 31 | med 31 | max 31]
+    change %  : [min +3.69% | med +3.69% | max +3.69%]
 
   heap_increase:
-    improved: 0, regressed: 0, unchanged: 1, new: 0, total: 1
-    change   : [min 0 | med 0 | max 0]
-    change % : [min 0% | med 0% | max 0%]
+    counts    : [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
+    change    : [min 0 | med 0 | max 0]
+    change %  : [min 0% | med 0% | max 0%]
 
   stable_memory_increase:
-    improved: 0, regressed: 0, unchanged: 1, new: 0, total: 1
-    change   : [min 0 | med 0 | max 0]
-    change % : [min 0% | med 0% | max 0%]
+    counts    : [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
+    change    : [min 0 | med 0 | max 0]
+    change %  : [min 0% | med 0% | max 0%]
 
 ---------------------------------------------------
 "
@@ -698,19 +698,19 @@ Benchmark: write_stable_memory (new)
 
 Summary:
   instructions:
-    improved: 0, regressed: 0, unchanged: 0, new: 1, total: 1
-    change   : [min 49.74 K | med 49.74 K | max 49.74 K]
-    change % : n/a
+    counts    : [total 1 | new 1 | improved 0 | regressed 0 | unchanged 0]
+    change    : [min 49.74 K | med 49.74 K | max 49.74 K]
+    change %  : n/a
 
   heap_increase:
-    improved: 0, regressed: 0, unchanged: 0, new: 1, total: 1
-    change   : [min 1 | med 1 | max 1]
-    change % : n/a
+    counts    : [total 1 | new 1 | improved 0 | regressed 0 | unchanged 0]
+    change    : [min 1 | med 1 | max 1]
+    change %  : n/a
 
   stable_memory_increase:
-    improved: 0, regressed: 0, unchanged: 0, new: 1, total: 1
-    change   : [min 1 | med 1 | max 1]
-    change % : n/a
+    counts    : [total 1 | new 1 | improved 0 | regressed 0 | unchanged 0]
+    change    : [min 1 | med 1 | max 1]
+    change %  : n/a
 
 ---------------------------------------------------
 "
@@ -773,19 +773,19 @@ Instruction traces written to write_stable_memory.svg
 
 Summary:
   instructions:
-    improved: 0, regressed: 0, unchanged: 0, new: 1, total: 1
-    change   : [min 49.74 K | med 49.74 K | max 49.74 K]
-    change % : n/a
+    counts    : [total 1 | new 1 | improved 0 | regressed 0 | unchanged 0]
+    change    : [min 49.74 K | med 49.74 K | max 49.74 K]
+    change %  : n/a
 
   heap_increase:
-    improved: 0, regressed: 0, unchanged: 0, new: 1, total: 1
-    change   : [min 1 | med 1 | max 1]
-    change % : n/a
+    counts    : [total 1 | new 1 | improved 0 | regressed 0 | unchanged 0]
+    change    : [min 1 | med 1 | max 1]
+    change %  : n/a
 
   stable_memory_increase:
-    improved: 0, regressed: 0, unchanged: 0, new: 1, total: 1
-    change   : [min 1 | med 1 | max 1]
-    change % : n/a
+    counts    : [total 1 | new 1 | improved 0 | regressed 0 | unchanged 0]
+    change    : [min 1 | med 1 | max 1]
+    change %  : n/a
 
 ---------------------------------------------------
 "
@@ -818,19 +818,19 @@ Benchmark: bench_repeated_scope_new (new)
 
 Summary:
   instructions:
-    improved: 0, regressed: 0, unchanged: 0, new: 1, total: 1
-    change   : [min 16.97 K | med 16.97 K | max 16.97 K]
-    change % : n/a
+    counts    : [total 1 | new 1 | improved 0 | regressed 0 | unchanged 0]
+    change    : [min 16.97 K | med 16.97 K | max 16.97 K]
+    change %  : n/a
 
   heap_increase:
-    improved: 0, regressed: 0, unchanged: 0, new: 1, total: 1
-    change   : [min 1 | med 1 | max 1]
-    change % : n/a
+    counts    : [total 1 | new 1 | improved 0 | regressed 0 | unchanged 0]
+    change    : [min 1 | med 1 | max 1]
+    change %  : n/a
 
   stable_memory_increase:
-    improved: 0, regressed: 0, unchanged: 0, new: 1, total: 1
-    change   : [min 0 | med 0 | max 0]
-    change % : n/a
+    counts    : [total 1 | new 1 | improved 0 | regressed 0 | unchanged 0]
+    change    : [min 0 | med 0 | max 0]
+    change %  : n/a
 
 ---------------------------------------------------
 "
@@ -863,19 +863,19 @@ Benchmark: bench_repeated_scope_exists
 
 Summary:
   instructions:
-    improved: 0, regressed: 1, unchanged: 0, new: 0, total: 1
-    change   : [min 16.97 K | med 16.97 K | max 16.97 K]
-    change % : n/a
+    counts    : [total 1 | new 0 | improved 0 | regressed 1 | unchanged 0]
+    change    : [min 16.97 K | med 16.97 K | max 16.97 K]
+    change %  : n/a
 
   heap_increase:
-    improved: 0, regressed: 1, unchanged: 0, new: 0, total: 1
-    change   : [min 1 | med 1 | max 1]
-    change % : n/a
+    counts    : [total 1 | new 0 | improved 0 | regressed 1 | unchanged 0]
+    change    : [min 1 | med 1 | max 1]
+    change %  : n/a
 
   stable_memory_increase:
-    improved: 0, regressed: 0, unchanged: 1, new: 0, total: 1
-    change   : [min 0 | med 0 | max 0]
-    change % : [min 0% | med 0% | max 0%]
+    counts    : [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
+    change    : [min 0 | med 0 | max 0]
+    change %  : [min 0% | med 0% | max 0%]
 
 ---------------------------------------------------
 "

--- a/canbench-bin/tests/tests.rs
+++ b/canbench-bin/tests/tests.rs
@@ -171,17 +171,17 @@ Benchmark: noisy_change_above_default_threshold_test
 
 Summary:
   instructions:
-    counts    : [total 1 | new 0 | improved 1 | regressed 0 | unchanged 0]
+    counts    : [total 1 | new 0 | improved 1 | regressed 0 | unchanged 0] 🟢
     change    : [min -154.07 K | med -154.07 K | max -154.07 K]
     change %  : [min -4.35% | med -4.35% | max -4.35%]
 
   heap_increase:
-    counts    : [total 1 | new 0 | improved 1 | regressed 0 | unchanged 0]
+    counts    : [total 1 | new 0 | improved 1 | regressed 0 | unchanged 0] 🟢
     change    : [min -3 | med -3 | max -3]
     change %  : [min -4.62% | med -4.62% | max -4.62%]
 
   stable_memory_increase:
-    counts    : [total 1 | new 0 | improved 1 | regressed 0 | unchanged 0]
+    counts    : [total 1 | new 0 | improved 1 | regressed 0 | unchanged 0] 🟢
     change    : [min -4 | med -4 | max -4]
     change %  : [min -3.85% | med -3.85% | max -3.85%]
 
@@ -252,7 +252,7 @@ Benchmark: regression_test
 
 Summary:
   instructions:
-    counts    : [total 1 | new 0 | improved 0 | regressed 1 | unchanged 0]
+    counts    : [total 1 | new 0 | improved 0 | regressed 1 | unchanged 0] 🔴
     change    : [min 197 | med 197 | max 197]
     change %  : [min +1970.00% | med +1970.00% | max +1970.00%]
 
@@ -292,7 +292,7 @@ Benchmark: improvement_test
 
 Summary:
   instructions:
-    counts    : [total 1 | new 0 | improved 1 | regressed 0 | unchanged 0]
+    counts    : [total 1 | new 0 | improved 1 | regressed 0 | unchanged 0] 🟢
     change    : [min -2.89 K | med -2.89 K | max -2.89 K]
     change %  : [min -93.32% | med -93.32% | max -93.32%]
 
@@ -332,7 +332,7 @@ Benchmark: stable_memory_increase_from_zero
 
 Summary:
   instructions:
-    counts    : [total 1 | new 0 | improved 0 | regressed 1 | unchanged 0]
+    counts    : [total 1 | new 0 | improved 0 | regressed 1 | unchanged 0] 🔴
     change    : [min 307 | med 307 | max 307]
     change %  : n/a
 
@@ -342,7 +342,7 @@ Summary:
     change %  : [min 0% | med 0% | max 0%]
 
   stable_memory_increase:
-    counts    : [total 1 | new 0 | improved 0 | regressed 1 | unchanged 0]
+    counts    : [total 1 | new 0 | improved 0 | regressed 1 | unchanged 0] 🔴
     change    : [min 123 | med 123 | max 123]
     change %  : n/a
 
@@ -605,12 +605,12 @@ Benchmark: bench_scope_exists
 
 Summary:
   instructions:
-    counts    : [total 1 | new 0 | improved 0 | regressed 1 | unchanged 0]
+    counts    : [total 1 | new 0 | improved 0 | regressed 1 | unchanged 0] 🔴
     change    : [min 4.63 K | med 4.63 K | max 4.63 K]
     change %  : n/a
 
   heap_increase:
-    counts    : [total 1 | new 0 | improved 0 | regressed 1 | unchanged 0]
+    counts    : [total 1 | new 0 | improved 0 | regressed 1 | unchanged 0] 🔴
     change    : [min 1 | med 1 | max 1]
     change %  : n/a
 
@@ -657,7 +657,7 @@ Benchmark: state_check
 
 Summary:
   instructions:
-    counts    : [total 1 | new 0 | improved 0 | regressed 1 | unchanged 0]
+    counts    : [total 1 | new 0 | improved 0 | regressed 1 | unchanged 0] 🔴
     change    : [min 31 | med 31 | max 31]
     change %  : [min +3.69% | med +3.69% | max +3.69%]
 
@@ -863,12 +863,12 @@ Benchmark: bench_repeated_scope_exists
 
 Summary:
   instructions:
-    counts    : [total 1 | new 0 | improved 0 | regressed 1 | unchanged 0]
+    counts    : [total 1 | new 0 | improved 0 | regressed 1 | unchanged 0] 🔴
     change    : [min 16.97 K | med 16.97 K | max 16.97 K]
     change %  : n/a
 
   heap_increase:
-    counts    : [total 1 | new 0 | improved 0 | regressed 1 | unchanged 0]
+    counts    : [total 1 | new 0 | improved 0 | regressed 1 | unchanged 0] 🔴
     change    : [min 1 | med 1 | max 1]
     change %  : n/a
 

--- a/canbench-bin/tests/tests.rs
+++ b/canbench-bin/tests/tests.rs
@@ -44,17 +44,17 @@ Benchmark: no_changes_test
 
 Summary:
   instructions:
-    changed: 0, unchanged: 1, new: 0, total: 1
+    improved: 0, regressed: 0, unchanged: 1, new: 0, total: 1
     change   : [min 0 | med 0 | max 0]
     change % : [min 0% | med 0% | max 0%]
 
   heap_increase:
-    changed: 0, unchanged: 1, new: 0, total: 1
+    improved: 0, regressed: 0, unchanged: 1, new: 0, total: 1
     change   : [min 0 | med 0 | max 0]
     change % : [min 0% | med 0% | max 0%]
 
   stable_memory_increase:
-    changed: 0, unchanged: 1, new: 0, total: 1
+    improved: 0, regressed: 0, unchanged: 1, new: 0, total: 1
     change   : [min 0 | med 0 | max 0]
     change % : [min 0% | med 0% | max 0%]
 
@@ -77,17 +77,17 @@ fn benchmark_reports_no_changes_with_hide_results() {
 
 Summary:
   instructions:
-    changed: 0, unchanged: 1, new: 0, total: 1
+    improved: 0, regressed: 0, unchanged: 1, new: 0, total: 1
     change   : [min 0 | med 0 | max 0]
     change % : [min 0% | med 0% | max 0%]
 
   heap_increase:
-    changed: 0, unchanged: 1, new: 0, total: 1
+    improved: 0, regressed: 0, unchanged: 1, new: 0, total: 1
     change   : [min 0 | med 0 | max 0]
     change % : [min 0% | med 0% | max 0%]
 
   stable_memory_increase:
-    changed: 0, unchanged: 1, new: 0, total: 1
+    improved: 0, regressed: 0, unchanged: 1, new: 0, total: 1
     change   : [min 0 | med 0 | max 0]
     change % : [min 0% | med 0% | max 0%]
 
@@ -131,17 +131,17 @@ Benchmark: noisy_change_test
 
 Summary:
   instructions:
-    changed: 0, unchanged: 1, new: 0, total: 1
+    improved: 0, regressed: 0, unchanged: 1, new: 0, total: 1
     change   : [min -3 | med -3 | max -3]
     change % : [min -1.43% | med -1.43% | max -1.43%]
 
   heap_increase:
-    changed: 0, unchanged: 1, new: 0, total: 1
+    improved: 0, regressed: 0, unchanged: 1, new: 0, total: 1
     change   : [min 0 | med 0 | max 0]
     change % : [min 0% | med 0% | max 0%]
 
   stable_memory_increase:
-    changed: 0, unchanged: 1, new: 0, total: 1
+    improved: 0, regressed: 0, unchanged: 1, new: 0, total: 1
     change   : [min 0 | med 0 | max 0]
     change % : [min 0% | med 0% | max 0%]
 
@@ -171,17 +171,17 @@ Benchmark: noisy_change_above_default_threshold_test
 
 Summary:
   instructions:
-    changed: 1, unchanged: 0, new: 0, total: 1
+    improved: 1, regressed: 0, unchanged: 0, new: 0, total: 1
     change   : [min -154.07 K | med -154.07 K | max -154.07 K]
     change % : [min -4.35% | med -4.35% | max -4.35%]
 
   heap_increase:
-    changed: 1, unchanged: 0, new: 0, total: 1
+    improved: 1, regressed: 0, unchanged: 0, new: 0, total: 1
     change   : [min -3 | med -3 | max -3]
     change % : [min -4.62% | med -4.62% | max -4.62%]
 
   stable_memory_increase:
-    changed: 1, unchanged: 0, new: 0, total: 1
+    improved: 1, regressed: 0, unchanged: 0, new: 0, total: 1
     change   : [min -4 | med -4 | max -4]
     change % : [min -3.85% | med -3.85% | max -3.85%]
 
@@ -212,17 +212,17 @@ Benchmark: noisy_change_above_default_threshold_test
 
 Summary:
   instructions:
-    changed: 0, unchanged: 1, new: 0, total: 1
+    improved: 0, regressed: 0, unchanged: 1, new: 0, total: 1
     change   : [min -154.07 K | med -154.07 K | max -154.07 K]
     change % : [min -4.35% | med -4.35% | max -4.35%]
 
   heap_increase:
-    changed: 0, unchanged: 1, new: 0, total: 1
+    improved: 0, regressed: 0, unchanged: 1, new: 0, total: 1
     change   : [min -3 | med -3 | max -3]
     change % : [min -4.62% | med -4.62% | max -4.62%]
 
   stable_memory_increase:
-    changed: 0, unchanged: 1, new: 0, total: 1
+    improved: 0, regressed: 0, unchanged: 1, new: 0, total: 1
     change   : [min -4 | med -4 | max -4]
     change % : [min -3.85% | med -3.85% | max -3.85%]
 
@@ -252,17 +252,17 @@ Benchmark: regression_test
 
 Summary:
   instructions:
-    changed: 1, unchanged: 0, new: 0, total: 1
+    improved: 0, regressed: 1, unchanged: 0, new: 0, total: 1
     change   : [min 197 | med 197 | max 197]
     change % : [min +1970.00% | med +1970.00% | max +1970.00%]
 
   heap_increase:
-    changed: 0, unchanged: 1, new: 0, total: 1
+    improved: 0, regressed: 0, unchanged: 1, new: 0, total: 1
     change   : [min 0 | med 0 | max 0]
     change % : [min 0% | med 0% | max 0%]
 
   stable_memory_increase:
-    changed: 0, unchanged: 1, new: 0, total: 1
+    improved: 0, regressed: 0, unchanged: 1, new: 0, total: 1
     change   : [min 0 | med 0 | max 0]
     change % : [min 0% | med 0% | max 0%]
 
@@ -292,17 +292,17 @@ Benchmark: improvement_test
 
 Summary:
   instructions:
-    changed: 1, unchanged: 0, new: 0, total: 1
+    improved: 1, regressed: 0, unchanged: 0, new: 0, total: 1
     change   : [min -2.89 K | med -2.89 K | max -2.89 K]
     change % : [min -93.32% | med -93.32% | max -93.32%]
 
   heap_increase:
-    changed: 0, unchanged: 1, new: 0, total: 1
+    improved: 0, regressed: 0, unchanged: 1, new: 0, total: 1
     change   : [min 0 | med 0 | max 0]
     change % : [min 0% | med 0% | max 0%]
 
   stable_memory_increase:
-    changed: 0, unchanged: 1, new: 0, total: 1
+    improved: 0, regressed: 0, unchanged: 1, new: 0, total: 1
     change   : [min 0 | med 0 | max 0]
     change % : [min 0% | med 0% | max 0%]
 
@@ -332,17 +332,17 @@ Benchmark: stable_memory_increase_from_zero
 
 Summary:
   instructions:
-    changed: 1, unchanged: 0, new: 0, total: 1
+    improved: 0, regressed: 1, unchanged: 0, new: 0, total: 1
     change   : [min 307 | med 307 | max 307]
     change % : n/a
 
   heap_increase:
-    changed: 0, unchanged: 1, new: 0, total: 1
+    improved: 0, regressed: 0, unchanged: 1, new: 0, total: 1
     change   : [min 0 | med 0 | max 0]
     change % : [min 0% | med 0% | max 0%]
 
   stable_memory_increase:
-    changed: 1, unchanged: 0, new: 0, total: 1
+    improved: 0, regressed: 1, unchanged: 0, new: 0, total: 1
     change   : [min 123 | med 123 | max 123]
     change % : n/a
 
@@ -374,17 +374,17 @@ Benchmark: stable_memory_only_increase (new)
 
 Summary:
   instructions:
-    changed: 0, unchanged: 0, new: 1, total: 1
+    improved: 0, regressed: 0, unchanged: 0, new: 1, total: 1
     change   : [min 307 | med 307 | max 307]
     change % : n/a
 
   heap_increase:
-    changed: 0, unchanged: 0, new: 1, total: 1
+    improved: 0, regressed: 0, unchanged: 0, new: 1, total: 1
     change   : [min 0 | med 0 | max 0]
     change % : n/a
 
   stable_memory_increase:
-    changed: 0, unchanged: 0, new: 1, total: 1
+    improved: 0, regressed: 0, unchanged: 0, new: 1, total: 1
     change   : [min 456 | med 456 | max 456]
     change % : n/a
 
@@ -414,17 +414,17 @@ Benchmark: increase_heap_increase (new)
 
 Summary:
   instructions:
-    changed: 0, unchanged: 0, new: 1, total: 1
+    improved: 0, regressed: 0, unchanged: 0, new: 1, total: 1
     change   : [min 3.39 M | med 3.39 M | max 3.39 M]
     change % : n/a
 
   heap_increase:
-    changed: 0, unchanged: 0, new: 1, total: 1
+    improved: 0, regressed: 0, unchanged: 0, new: 1, total: 1
     change   : [min 62 | med 62 | max 62]
     change % : n/a
 
   stable_memory_increase:
-    changed: 0, unchanged: 0, new: 1, total: 1
+    improved: 0, regressed: 0, unchanged: 0, new: 1, total: 1
     change   : [min 0 | med 0 | max 0]
     change % : n/a
 
@@ -460,17 +460,17 @@ Benchmark: bench_2 (new)
 
 Summary:
   instructions:
-    changed: 0, unchanged: 0, new: 2, total: 2
+    improved: 0, regressed: 0, unchanged: 0, new: 2, total: 2
     change   : [min 207 | med 207 | max 207]
     change % : n/a
 
   heap_increase:
-    changed: 0, unchanged: 0, new: 2, total: 2
+    improved: 0, regressed: 0, unchanged: 0, new: 2, total: 2
     change   : [min 0 | med 0 | max 0]
     change % : n/a
 
   stable_memory_increase:
-    changed: 0, unchanged: 0, new: 2, total: 2
+    improved: 0, regressed: 0, unchanged: 0, new: 2, total: 2
     change   : [min 0 | med 0 | max 0]
     change % : n/a
 
@@ -510,17 +510,17 @@ Benchmark: bench_scope_new (new)
 
 Summary:
   instructions:
-    changed: 0, unchanged: 0, new: 1, total: 1
+    improved: 0, regressed: 0, unchanged: 0, new: 1, total: 1
     change   : [min 4.63 K | med 4.63 K | max 4.63 K]
     change % : n/a
 
   heap_increase:
-    changed: 0, unchanged: 0, new: 1, total: 1
+    improved: 0, regressed: 0, unchanged: 0, new: 1, total: 1
     change   : [min 1 | med 1 | max 1]
     change % : n/a
 
   stable_memory_increase:
-    changed: 0, unchanged: 0, new: 1, total: 1
+    improved: 0, regressed: 0, unchanged: 0, new: 1, total: 1
     change   : [min 0 | med 0 | max 0]
     change % : n/a
 
@@ -605,17 +605,17 @@ Benchmark: bench_scope_exists
 
 Summary:
   instructions:
-    changed: 1, unchanged: 0, new: 0, total: 1
+    improved: 0, regressed: 1, unchanged: 0, new: 0, total: 1
     change   : [min 4.63 K | med 4.63 K | max 4.63 K]
     change % : n/a
 
   heap_increase:
-    changed: 1, unchanged: 0, new: 0, total: 1
+    improved: 0, regressed: 1, unchanged: 0, new: 0, total: 1
     change   : [min 1 | med 1 | max 1]
     change % : n/a
 
   stable_memory_increase:
-    changed: 0, unchanged: 1, new: 0, total: 1
+    improved: 0, regressed: 0, unchanged: 1, new: 0, total: 1
     change   : [min 0 | med 0 | max 0]
     change % : [min 0% | med 0% | max 0%]
 
@@ -657,17 +657,17 @@ Benchmark: state_check
 
 Summary:
   instructions:
-    changed: 1, unchanged: 0, new: 0, total: 1
+    improved: 0, regressed: 1, unchanged: 0, new: 0, total: 1
     change   : [min 31 | med 31 | max 31]
     change % : [min +3.69% | med +3.69% | max +3.69%]
 
   heap_increase:
-    changed: 0, unchanged: 1, new: 0, total: 1
+    improved: 0, regressed: 0, unchanged: 1, new: 0, total: 1
     change   : [min 0 | med 0 | max 0]
     change % : [min 0% | med 0% | max 0%]
 
   stable_memory_increase:
-    changed: 0, unchanged: 1, new: 0, total: 1
+    improved: 0, regressed: 0, unchanged: 1, new: 0, total: 1
     change   : [min 0 | med 0 | max 0]
     change % : [min 0% | med 0% | max 0%]
 
@@ -698,17 +698,17 @@ Benchmark: write_stable_memory (new)
 
 Summary:
   instructions:
-    changed: 0, unchanged: 0, new: 1, total: 1
+    improved: 0, regressed: 0, unchanged: 0, new: 1, total: 1
     change   : [min 49.74 K | med 49.74 K | max 49.74 K]
     change % : n/a
 
   heap_increase:
-    changed: 0, unchanged: 0, new: 1, total: 1
+    improved: 0, regressed: 0, unchanged: 0, new: 1, total: 1
     change   : [min 1 | med 1 | max 1]
     change % : n/a
 
   stable_memory_increase:
-    changed: 0, unchanged: 0, new: 1, total: 1
+    improved: 0, regressed: 0, unchanged: 0, new: 1, total: 1
     change   : [min 1 | med 1 | max 1]
     change % : n/a
 
@@ -773,17 +773,17 @@ Instruction traces written to write_stable_memory.svg
 
 Summary:
   instructions:
-    changed: 0, unchanged: 0, new: 1, total: 1
+    improved: 0, regressed: 0, unchanged: 0, new: 1, total: 1
     change   : [min 49.74 K | med 49.74 K | max 49.74 K]
     change % : n/a
 
   heap_increase:
-    changed: 0, unchanged: 0, new: 1, total: 1
+    improved: 0, regressed: 0, unchanged: 0, new: 1, total: 1
     change   : [min 1 | med 1 | max 1]
     change % : n/a
 
   stable_memory_increase:
-    changed: 0, unchanged: 0, new: 1, total: 1
+    improved: 0, regressed: 0, unchanged: 0, new: 1, total: 1
     change   : [min 1 | med 1 | max 1]
     change % : n/a
 
@@ -818,17 +818,17 @@ Benchmark: bench_repeated_scope_new (new)
 
 Summary:
   instructions:
-    changed: 0, unchanged: 0, new: 1, total: 1
+    improved: 0, regressed: 0, unchanged: 0, new: 1, total: 1
     change   : [min 16.97 K | med 16.97 K | max 16.97 K]
     change % : n/a
 
   heap_increase:
-    changed: 0, unchanged: 0, new: 1, total: 1
+    improved: 0, regressed: 0, unchanged: 0, new: 1, total: 1
     change   : [min 1 | med 1 | max 1]
     change % : n/a
 
   stable_memory_increase:
-    changed: 0, unchanged: 0, new: 1, total: 1
+    improved: 0, regressed: 0, unchanged: 0, new: 1, total: 1
     change   : [min 0 | med 0 | max 0]
     change % : n/a
 
@@ -863,17 +863,17 @@ Benchmark: bench_repeated_scope_exists
 
 Summary:
   instructions:
-    changed: 1, unchanged: 0, new: 0, total: 1
+    improved: 0, regressed: 1, unchanged: 0, new: 0, total: 1
     change   : [min 16.97 K | med 16.97 K | max 16.97 K]
     change % : n/a
 
   heap_increase:
-    changed: 1, unchanged: 0, new: 0, total: 1
+    improved: 0, regressed: 1, unchanged: 0, new: 0, total: 1
     change   : [min 1 | med 1 | max 1]
     change % : n/a
 
   stable_memory_increase:
-    changed: 0, unchanged: 1, new: 0, total: 1
+    improved: 0, regressed: 0, unchanged: 1, new: 0, total: 1
     change   : [min 0 | med 0 | max 0]
     change % : [min 0% | med 0% | max 0%]
 

--- a/canbench-bin/tests/tests.rs
+++ b/canbench-bin/tests/tests.rs
@@ -44,19 +44,19 @@ Benchmark: no_changes_test
 
 Summary:
   instructions:
-    counts    : [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
-    change    : [min 0 | med 0 | max 0]
-    change %  : [min 0% | med 0% | max 0%]
+    counts:   [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
+    change:   [min 0 | med 0 | max 0]
+    change %: [min 0% | med 0% | max 0%]
 
   heap_increase:
-    counts    : [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
-    change    : [min 0 | med 0 | max 0]
-    change %  : [min 0% | med 0% | max 0%]
+    counts:   [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
+    change:   [min 0 | med 0 | max 0]
+    change %: [min 0% | med 0% | max 0%]
 
   stable_memory_increase:
-    counts    : [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
-    change    : [min 0 | med 0 | max 0]
-    change %  : [min 0% | med 0% | max 0%]
+    counts:   [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
+    change:   [min 0 | med 0 | max 0]
+    change %: [min 0% | med 0% | max 0%]
 
 ---------------------------------------------------
 "
@@ -77,19 +77,19 @@ fn benchmark_reports_no_changes_with_hide_results() {
 
 Summary:
   instructions:
-    counts    : [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
-    change    : [min 0 | med 0 | max 0]
-    change %  : [min 0% | med 0% | max 0%]
+    counts:   [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
+    change:   [min 0 | med 0 | max 0]
+    change %: [min 0% | med 0% | max 0%]
 
   heap_increase:
-    counts    : [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
-    change    : [min 0 | med 0 | max 0]
-    change %  : [min 0% | med 0% | max 0%]
+    counts:   [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
+    change:   [min 0 | med 0 | max 0]
+    change %: [min 0% | med 0% | max 0%]
 
   stable_memory_increase:
-    counts    : [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
-    change    : [min 0 | med 0 | max 0]
-    change %  : [min 0% | med 0% | max 0%]
+    counts:   [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
+    change:   [min 0 | med 0 | max 0]
+    change %: [min 0% | med 0% | max 0%]
 
 ---------------------------------------------------
 "
@@ -131,19 +131,19 @@ Benchmark: noisy_change_test
 
 Summary:
   instructions:
-    counts    : [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
-    change    : [min -3 | med -3 | max -3]
-    change %  : [min -1.43% | med -1.43% | max -1.43%]
+    counts:   [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
+    change:   [min -3 | med -3 | max -3]
+    change %: [min -1.43% | med -1.43% | max -1.43%]
 
   heap_increase:
-    counts    : [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
-    change    : [min 0 | med 0 | max 0]
-    change %  : [min 0% | med 0% | max 0%]
+    counts:   [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
+    change:   [min 0 | med 0 | max 0]
+    change %: [min 0% | med 0% | max 0%]
 
   stable_memory_increase:
-    counts    : [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
-    change    : [min 0 | med 0 | max 0]
-    change %  : [min 0% | med 0% | max 0%]
+    counts:   [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
+    change:   [min 0 | med 0 | max 0]
+    change %: [min 0% | med 0% | max 0%]
 
 ---------------------------------------------------
 "
@@ -171,19 +171,19 @@ Benchmark: noisy_change_above_default_threshold_test
 
 Summary:
   instructions:
-    counts    : [total 1 | new 0 | improved 1 | regressed 0 | unchanged 0] 🟢
-    change    : [min -154.07 K | med -154.07 K | max -154.07 K]
-    change %  : [min -4.35% | med -4.35% | max -4.35%]
+    counts:   [total 1 | new 0 | improved 1 | regressed 0 | unchanged 0] 🟢
+    change:   [min -154.07 K | med -154.07 K | max -154.07 K]
+    change %: [min -4.35% | med -4.35% | max -4.35%]
 
   heap_increase:
-    counts    : [total 1 | new 0 | improved 1 | regressed 0 | unchanged 0] 🟢
-    change    : [min -3 | med -3 | max -3]
-    change %  : [min -4.62% | med -4.62% | max -4.62%]
+    counts:   [total 1 | new 0 | improved 1 | regressed 0 | unchanged 0] 🟢
+    change:   [min -3 | med -3 | max -3]
+    change %: [min -4.62% | med -4.62% | max -4.62%]
 
   stable_memory_increase:
-    counts    : [total 1 | new 0 | improved 1 | regressed 0 | unchanged 0] 🟢
-    change    : [min -4 | med -4 | max -4]
-    change %  : [min -3.85% | med -3.85% | max -3.85%]
+    counts:   [total 1 | new 0 | improved 1 | regressed 0 | unchanged 0] 🟢
+    change:   [min -4 | med -4 | max -4]
+    change %: [min -3.85% | med -3.85% | max -3.85%]
 
 ---------------------------------------------------
 "
@@ -212,19 +212,19 @@ Benchmark: noisy_change_above_default_threshold_test
 
 Summary:
   instructions:
-    counts    : [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
-    change    : [min -154.07 K | med -154.07 K | max -154.07 K]
-    change %  : [min -4.35% | med -4.35% | max -4.35%]
+    counts:   [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
+    change:   [min -154.07 K | med -154.07 K | max -154.07 K]
+    change %: [min -4.35% | med -4.35% | max -4.35%]
 
   heap_increase:
-    counts    : [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
-    change    : [min -3 | med -3 | max -3]
-    change %  : [min -4.62% | med -4.62% | max -4.62%]
+    counts:   [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
+    change:   [min -3 | med -3 | max -3]
+    change %: [min -4.62% | med -4.62% | max -4.62%]
 
   stable_memory_increase:
-    counts    : [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
-    change    : [min -4 | med -4 | max -4]
-    change %  : [min -3.85% | med -3.85% | max -3.85%]
+    counts:   [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
+    change:   [min -4 | med -4 | max -4]
+    change %: [min -3.85% | med -3.85% | max -3.85%]
 
 ---------------------------------------------------
 "
@@ -252,19 +252,19 @@ Benchmark: regression_test
 
 Summary:
   instructions:
-    counts    : [total 1 | new 0 | improved 0 | regressed 1 | unchanged 0] 🔴
-    change    : [min 197 | med 197 | max 197]
-    change %  : [min +1970.00% | med +1970.00% | max +1970.00%]
+    counts:   [total 1 | new 0 | improved 0 | regressed 1 | unchanged 0] 🔴
+    change:   [min 197 | med 197 | max 197]
+    change %: [min +1970.00% | med +1970.00% | max +1970.00%]
 
   heap_increase:
-    counts    : [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
-    change    : [min 0 | med 0 | max 0]
-    change %  : [min 0% | med 0% | max 0%]
+    counts:   [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
+    change:   [min 0 | med 0 | max 0]
+    change %: [min 0% | med 0% | max 0%]
 
   stable_memory_increase:
-    counts    : [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
-    change    : [min 0 | med 0 | max 0]
-    change %  : [min 0% | med 0% | max 0%]
+    counts:   [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
+    change:   [min 0 | med 0 | max 0]
+    change %: [min 0% | med 0% | max 0%]
 
 ---------------------------------------------------
 "
@@ -292,19 +292,19 @@ Benchmark: improvement_test
 
 Summary:
   instructions:
-    counts    : [total 1 | new 0 | improved 1 | regressed 0 | unchanged 0] 🟢
-    change    : [min -2.89 K | med -2.89 K | max -2.89 K]
-    change %  : [min -93.32% | med -93.32% | max -93.32%]
+    counts:   [total 1 | new 0 | improved 1 | regressed 0 | unchanged 0] 🟢
+    change:   [min -2.89 K | med -2.89 K | max -2.89 K]
+    change %: [min -93.32% | med -93.32% | max -93.32%]
 
   heap_increase:
-    counts    : [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
-    change    : [min 0 | med 0 | max 0]
-    change %  : [min 0% | med 0% | max 0%]
+    counts:   [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
+    change:   [min 0 | med 0 | max 0]
+    change %: [min 0% | med 0% | max 0%]
 
   stable_memory_increase:
-    counts    : [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
-    change    : [min 0 | med 0 | max 0]
-    change %  : [min 0% | med 0% | max 0%]
+    counts:   [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
+    change:   [min 0 | med 0 | max 0]
+    change %: [min 0% | med 0% | max 0%]
 
 ---------------------------------------------------
 "
@@ -332,19 +332,19 @@ Benchmark: stable_memory_increase_from_zero
 
 Summary:
   instructions:
-    counts    : [total 1 | new 0 | improved 0 | regressed 1 | unchanged 0] 🔴
-    change    : [min 307 | med 307 | max 307]
-    change %  : n/a
+    counts:   [total 1 | new 0 | improved 0 | regressed 1 | unchanged 0] 🔴
+    change:   [min 307 | med 307 | max 307]
+    change %: n/a
 
   heap_increase:
-    counts    : [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
-    change    : [min 0 | med 0 | max 0]
-    change %  : [min 0% | med 0% | max 0%]
+    counts:   [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
+    change:   [min 0 | med 0 | max 0]
+    change %: [min 0% | med 0% | max 0%]
 
   stable_memory_increase:
-    counts    : [total 1 | new 0 | improved 0 | regressed 1 | unchanged 0] 🔴
-    change    : [min 123 | med 123 | max 123]
-    change %  : n/a
+    counts:   [total 1 | new 0 | improved 0 | regressed 1 | unchanged 0] 🔴
+    change:   [min 123 | med 123 | max 123]
+    change %: n/a
 
 ---------------------------------------------------
 "
@@ -374,19 +374,19 @@ Benchmark: stable_memory_only_increase (new)
 
 Summary:
   instructions:
-    counts    : [total 1 | new 1 | improved 0 | regressed 0 | unchanged 0]
-    change    : [min 307 | med 307 | max 307]
-    change %  : n/a
+    counts:   [total 1 | new 1 | improved 0 | regressed 0 | unchanged 0]
+    change:   [min 307 | med 307 | max 307]
+    change %: n/a
 
   heap_increase:
-    counts    : [total 1 | new 1 | improved 0 | regressed 0 | unchanged 0]
-    change    : [min 0 | med 0 | max 0]
-    change %  : n/a
+    counts:   [total 1 | new 1 | improved 0 | regressed 0 | unchanged 0]
+    change:   [min 0 | med 0 | max 0]
+    change %: n/a
 
   stable_memory_increase:
-    counts    : [total 1 | new 1 | improved 0 | regressed 0 | unchanged 0]
-    change    : [min 456 | med 456 | max 456]
-    change %  : n/a
+    counts:   [total 1 | new 1 | improved 0 | regressed 0 | unchanged 0]
+    change:   [min 456 | med 456 | max 456]
+    change %: n/a
 
 ---------------------------------------------------
 "
@@ -414,19 +414,19 @@ Benchmark: increase_heap_increase (new)
 
 Summary:
   instructions:
-    counts    : [total 1 | new 1 | improved 0 | regressed 0 | unchanged 0]
-    change    : [min 3.39 M | med 3.39 M | max 3.39 M]
-    change %  : n/a
+    counts:   [total 1 | new 1 | improved 0 | regressed 0 | unchanged 0]
+    change:   [min 3.39 M | med 3.39 M | max 3.39 M]
+    change %: n/a
 
   heap_increase:
-    counts    : [total 1 | new 1 | improved 0 | regressed 0 | unchanged 0]
-    change    : [min 62 | med 62 | max 62]
-    change %  : n/a
+    counts:   [total 1 | new 1 | improved 0 | regressed 0 | unchanged 0]
+    change:   [min 62 | med 62 | max 62]
+    change %: n/a
 
   stable_memory_increase:
-    counts    : [total 1 | new 1 | improved 0 | regressed 0 | unchanged 0]
-    change    : [min 0 | med 0 | max 0]
-    change %  : n/a
+    counts:   [total 1 | new 1 | improved 0 | regressed 0 | unchanged 0]
+    change:   [min 0 | med 0 | max 0]
+    change %: n/a
 
 ---------------------------------------------------
 "
@@ -460,19 +460,19 @@ Benchmark: bench_2 (new)
 
 Summary:
   instructions:
-    counts    : [total 2 | new 2 | improved 0 | regressed 0 | unchanged 0]
-    change    : [min 207 | med 207 | max 207]
-    change %  : n/a
+    counts:   [total 2 | new 2 | improved 0 | regressed 0 | unchanged 0]
+    change:   [min 207 | med 207 | max 207]
+    change %: n/a
 
   heap_increase:
-    counts    : [total 2 | new 2 | improved 0 | regressed 0 | unchanged 0]
-    change    : [min 0 | med 0 | max 0]
-    change %  : n/a
+    counts:   [total 2 | new 2 | improved 0 | regressed 0 | unchanged 0]
+    change:   [min 0 | med 0 | max 0]
+    change %: n/a
 
   stable_memory_increase:
-    counts    : [total 2 | new 2 | improved 0 | regressed 0 | unchanged 0]
-    change    : [min 0 | med 0 | max 0]
-    change %  : n/a
+    counts:   [total 2 | new 2 | improved 0 | regressed 0 | unchanged 0]
+    change:   [min 0 | med 0 | max 0]
+    change %: n/a
 
 ---------------------------------------------------
 "
@@ -510,19 +510,19 @@ Benchmark: bench_scope_new (new)
 
 Summary:
   instructions:
-    counts    : [total 1 | new 1 | improved 0 | regressed 0 | unchanged 0]
-    change    : [min 4.63 K | med 4.63 K | max 4.63 K]
-    change %  : n/a
+    counts:   [total 1 | new 1 | improved 0 | regressed 0 | unchanged 0]
+    change:   [min 4.63 K | med 4.63 K | max 4.63 K]
+    change %: n/a
 
   heap_increase:
-    counts    : [total 1 | new 1 | improved 0 | regressed 0 | unchanged 0]
-    change    : [min 1 | med 1 | max 1]
-    change %  : n/a
+    counts:   [total 1 | new 1 | improved 0 | regressed 0 | unchanged 0]
+    change:   [min 1 | med 1 | max 1]
+    change %: n/a
 
   stable_memory_increase:
-    counts    : [total 1 | new 1 | improved 0 | regressed 0 | unchanged 0]
-    change    : [min 0 | med 0 | max 0]
-    change %  : n/a
+    counts:   [total 1 | new 1 | improved 0 | regressed 0 | unchanged 0]
+    change:   [min 0 | med 0 | max 0]
+    change %: n/a
 
 ---------------------------------------------------
 "
@@ -605,19 +605,19 @@ Benchmark: bench_scope_exists
 
 Summary:
   instructions:
-    counts    : [total 1 | new 0 | improved 0 | regressed 1 | unchanged 0] 🔴
-    change    : [min 4.63 K | med 4.63 K | max 4.63 K]
-    change %  : n/a
+    counts:   [total 1 | new 0 | improved 0 | regressed 1 | unchanged 0] 🔴
+    change:   [min 4.63 K | med 4.63 K | max 4.63 K]
+    change %: n/a
 
   heap_increase:
-    counts    : [total 1 | new 0 | improved 0 | regressed 1 | unchanged 0] 🔴
-    change    : [min 1 | med 1 | max 1]
-    change %  : n/a
+    counts:   [total 1 | new 0 | improved 0 | regressed 1 | unchanged 0] 🔴
+    change:   [min 1 | med 1 | max 1]
+    change %: n/a
 
   stable_memory_increase:
-    counts    : [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
-    change    : [min 0 | med 0 | max 0]
-    change %  : [min 0% | med 0% | max 0%]
+    counts:   [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
+    change:   [min 0 | med 0 | max 0]
+    change %: [min 0% | med 0% | max 0%]
 
 ---------------------------------------------------
 "
@@ -657,19 +657,19 @@ Benchmark: state_check
 
 Summary:
   instructions:
-    counts    : [total 1 | new 0 | improved 0 | regressed 1 | unchanged 0] 🔴
-    change    : [min 31 | med 31 | max 31]
-    change %  : [min +3.69% | med +3.69% | max +3.69%]
+    counts:   [total 1 | new 0 | improved 0 | regressed 1 | unchanged 0] 🔴
+    change:   [min 31 | med 31 | max 31]
+    change %: [min +3.69% | med +3.69% | max +3.69%]
 
   heap_increase:
-    counts    : [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
-    change    : [min 0 | med 0 | max 0]
-    change %  : [min 0% | med 0% | max 0%]
+    counts:   [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
+    change:   [min 0 | med 0 | max 0]
+    change %: [min 0% | med 0% | max 0%]
 
   stable_memory_increase:
-    counts    : [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
-    change    : [min 0 | med 0 | max 0]
-    change %  : [min 0% | med 0% | max 0%]
+    counts:   [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
+    change:   [min 0 | med 0 | max 0]
+    change %: [min 0% | med 0% | max 0%]
 
 ---------------------------------------------------
 "
@@ -698,19 +698,19 @@ Benchmark: write_stable_memory (new)
 
 Summary:
   instructions:
-    counts    : [total 1 | new 1 | improved 0 | regressed 0 | unchanged 0]
-    change    : [min 49.74 K | med 49.74 K | max 49.74 K]
-    change %  : n/a
+    counts:   [total 1 | new 1 | improved 0 | regressed 0 | unchanged 0]
+    change:   [min 49.74 K | med 49.74 K | max 49.74 K]
+    change %: n/a
 
   heap_increase:
-    counts    : [total 1 | new 1 | improved 0 | regressed 0 | unchanged 0]
-    change    : [min 1 | med 1 | max 1]
-    change %  : n/a
+    counts:   [total 1 | new 1 | improved 0 | regressed 0 | unchanged 0]
+    change:   [min 1 | med 1 | max 1]
+    change %: n/a
 
   stable_memory_increase:
-    counts    : [total 1 | new 1 | improved 0 | regressed 0 | unchanged 0]
-    change    : [min 1 | med 1 | max 1]
-    change %  : n/a
+    counts:   [total 1 | new 1 | improved 0 | regressed 0 | unchanged 0]
+    change:   [min 1 | med 1 | max 1]
+    change %: n/a
 
 ---------------------------------------------------
 "
@@ -773,19 +773,19 @@ Instruction traces written to write_stable_memory.svg
 
 Summary:
   instructions:
-    counts    : [total 1 | new 1 | improved 0 | regressed 0 | unchanged 0]
-    change    : [min 49.74 K | med 49.74 K | max 49.74 K]
-    change %  : n/a
+    counts:   [total 1 | new 1 | improved 0 | regressed 0 | unchanged 0]
+    change:   [min 49.74 K | med 49.74 K | max 49.74 K]
+    change %: n/a
 
   heap_increase:
-    counts    : [total 1 | new 1 | improved 0 | regressed 0 | unchanged 0]
-    change    : [min 1 | med 1 | max 1]
-    change %  : n/a
+    counts:   [total 1 | new 1 | improved 0 | regressed 0 | unchanged 0]
+    change:   [min 1 | med 1 | max 1]
+    change %: n/a
 
   stable_memory_increase:
-    counts    : [total 1 | new 1 | improved 0 | regressed 0 | unchanged 0]
-    change    : [min 1 | med 1 | max 1]
-    change %  : n/a
+    counts:   [total 1 | new 1 | improved 0 | regressed 0 | unchanged 0]
+    change:   [min 1 | med 1 | max 1]
+    change %: n/a
 
 ---------------------------------------------------
 "
@@ -818,19 +818,19 @@ Benchmark: bench_repeated_scope_new (new)
 
 Summary:
   instructions:
-    counts    : [total 1 | new 1 | improved 0 | regressed 0 | unchanged 0]
-    change    : [min 16.97 K | med 16.97 K | max 16.97 K]
-    change %  : n/a
+    counts:   [total 1 | new 1 | improved 0 | regressed 0 | unchanged 0]
+    change:   [min 16.97 K | med 16.97 K | max 16.97 K]
+    change %: n/a
 
   heap_increase:
-    counts    : [total 1 | new 1 | improved 0 | regressed 0 | unchanged 0]
-    change    : [min 1 | med 1 | max 1]
-    change %  : n/a
+    counts:   [total 1 | new 1 | improved 0 | regressed 0 | unchanged 0]
+    change:   [min 1 | med 1 | max 1]
+    change %: n/a
 
   stable_memory_increase:
-    counts    : [total 1 | new 1 | improved 0 | regressed 0 | unchanged 0]
-    change    : [min 0 | med 0 | max 0]
-    change %  : n/a
+    counts:   [total 1 | new 1 | improved 0 | regressed 0 | unchanged 0]
+    change:   [min 0 | med 0 | max 0]
+    change %: n/a
 
 ---------------------------------------------------
 "
@@ -863,19 +863,19 @@ Benchmark: bench_repeated_scope_exists
 
 Summary:
   instructions:
-    counts    : [total 1 | new 0 | improved 0 | regressed 1 | unchanged 0] 🔴
-    change    : [min 16.97 K | med 16.97 K | max 16.97 K]
-    change %  : n/a
+    counts:   [total 1 | new 0 | improved 0 | regressed 1 | unchanged 0] 🔴
+    change:   [min 16.97 K | med 16.97 K | max 16.97 K]
+    change %: n/a
 
   heap_increase:
-    counts    : [total 1 | new 0 | improved 0 | regressed 1 | unchanged 0] 🔴
-    change    : [min 1 | med 1 | max 1]
-    change %  : n/a
+    counts:   [total 1 | new 0 | improved 0 | regressed 1 | unchanged 0] 🔴
+    change:   [min 1 | med 1 | max 1]
+    change %: n/a
 
   stable_memory_increase:
-    counts    : [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
-    change    : [min 0 | med 0 | max 0]
-    change %  : [min 0% | med 0% | max 0%]
+    counts:   [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
+    change:   [min 0 | med 0 | max 0]
+    change %: [min 0% | med 0% | max 0%]
 
 ---------------------------------------------------
 "


### PR DESCRIPTION
This PR replaces the generic `changed` count with separate `improved` and `regressed` counters for better clarity.

It also unifies the formatting of all summary lines to match the style of `change` and `change %`, and adds emoji indicators to highlight important changes at a glance.

The summary output format is inspired by the style used in the [Criterion](https://bheisler.github.io/criterion.rs/book/user_guide/command_line_output.html) crate.