### PR TITLE
feat: switch CSV delimiter from tab to comma

### DIFF
--- a/canbench-bin/src/csv_file.rs
+++ b/canbench-bin/src/csv_file.rs
@@ -3,7 +3,7 @@ use std::{collections::BTreeMap, fs::File, io::Write, path::PathBuf};
 
 /// Delimiter used in the CSV file.
 /// Tab `\t` avoids issues with commas in numbers or text and is reliably parsed by Google Sheets.
-const DELIMITER: char = '\t';
+const DELIMITER: char = ',';
 
 /// Write benchmark results to a CSV file.
 pub(crate) fn write(

--- a/canbench-bin/src/csv_file.rs
+++ b/canbench-bin/src/csv_file.rs
@@ -2,7 +2,8 @@ use canbench_rs::{BenchResult, Measurement};
 use std::{collections::BTreeMap, fs::File, io::Write, path::PathBuf};
 
 /// Delimiter used in the CSV file.
-/// Tab `\t` avoids issues with commas in numbers or text and is reliably parsed by Google Sheets.
+/// Use `,` for GitHub/VSCode preview.
+/// Use `\t` for better compatibility with Google Sheets.
 const DELIMITER: char = ',';
 
 /// Write benchmark results to a CSV file.

--- a/examples/btreemap_vs_hashmap/canbench_results.csv
+++ b/examples/btreemap_vs_hashmap/canbench_results.csv
@@ -1,4 +1,4 @@
-status	name	instructions	instructions %	heap_increase	heap_increase %	stable_memory_increase	stable_memory_increase %
-	insert_users	2558172740	0.00%	872	0.00%	0	
-	pre_upgrade_bench	438878782	0.00%	519	0.00%	184	0.00%
-	remove_users	2109060849	0.00%	0		0	
+status,name,instructions,instructions %,heap_increase,heap_increase %,stable_memory_increase,stable_memory_increase %
+,insert_users,2558172740,0.00%,872,0.00%,0,
+,pre_upgrade_bench,438878782,0.00%,519,0.00%,184,0.00%
+,remove_users,2109060849,0.00%,0,,0,

--- a/examples/fibonacci/canbench_results.csv
+++ b/examples/fibonacci/canbench_results.csv
@@ -1,6 +1,6 @@
-status	name	instructions	instructions %	heap_increase	heap_increase %	stable_memory_increase	stable_memory_increase %
-	fibonacci_20	726	0.00%	0		0	
-	fibonacci_45	1301	0.00%	0		0	
-	fibonacci_8a	450	0.00%	0		0	
-	fibonacci_8b	207	0.00%	0		0	
-	fibonacci_8c	391	0.00%	0		0	
+status,name,instructions,instructions %,heap_increase,heap_increase %,stable_memory_increase,stable_memory_increase %
+,fibonacci_20,726,0.00%,0,,0,
+,fibonacci_45,1301,0.00%,0,,0,
+,fibonacci_8a,450,0.00%,0,,0,
+,fibonacci_8b,207,0.00%,0,,0,
+,fibonacci_8c,391,0.00%,0,,0,


### PR DESCRIPTION
This PR changes the CSV delimiter to a comma (,) for better compatibility with GitHub and VSCode CSV previews.

This allows to easily sort tables right in your VSCode editor.

![image](https://github.com/user-attachments/assets/e0725783-6a8c-494b-8024-c49b5cce1c98)
![image](https://github.com/user-attachments/assets/c2376cc1-90dc-4019-9a6c-630c376a8a0e)
