### PR TITLE
chore: bump versions to 0.1.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,7 +242,7 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "canbench"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "canbench-rs",
  "candid",
@@ -266,7 +266,7 @@ dependencies = [
 
 [[package]]
 name = "canbench-rs"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "canbench-rs-macros",
  "candid",
@@ -277,7 +277,7 @@ dependencies = [
 
 [[package]]
 name = "canbench-rs-macros"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/canbench-bin/Cargo.toml
+++ b/canbench-bin/Cargo.toml
@@ -1,20 +1,20 @@
 [package]
 name = "canbench"
-# NOTE: whenever this version is updated, canbench-rs below should also be updated.
 description = "A benchmarking framework for canisters on the Internet Computer."
 edition = "2021"
 keywords = ["benchmark", "canister", "ic", "internet-computer", "perf"]
 license = "Apache-2.0"
 readme = "../README.md"
 repository = "https://github.com/dfinity/canbench"
-version = "0.1.11"
+# NOTE: whenever this version is updated, canbench-rs below should also be updated.
+version = "0.1.12"
 
 [[bin]]
 name = "canbench"
 path = "src/main.rs"
 
 [dependencies]
-canbench-rs = { path = "../canbench-rs", version = "0.1.11" }
+canbench-rs = { path = "../canbench-rs", version = "0.1.12" }
 candid.workspace = true
 clap.workspace = true
 colored.workspace = true

--- a/canbench-bin/Cargo.toml
+++ b/canbench-bin/Cargo.toml
@@ -6,7 +6,7 @@ keywords = ["benchmark", "canister", "ic", "internet-computer", "perf"]
 license = "Apache-2.0"
 readme = "../README.md"
 repository = "https://github.com/dfinity/canbench"
-# NOTE: whenever this version is updated, canbench-rs below should also be updated.
+# NOTE: Update `canbench-rs` version below when this changes.
 version = "0.1.12"
 
 [[bin]]

--- a/canbench-bin/tests/tests.rs
+++ b/canbench-bin/tests/tests.rs
@@ -276,7 +276,7 @@ fn newer_version() {
         .run(|output| {
         assert_err!(
                 output,
-                "canbench is at version 0.1.11 while the results were generated with version 99.0.0. Please upgrade canbench.
+                "canbench is at version 0.1.12 while the results were generated with version 99.0.0. Please upgrade canbench.
 "
             );
         });

--- a/canbench-rs-macros/Cargo.toml
+++ b/canbench-rs-macros/Cargo.toml
@@ -4,7 +4,7 @@ edition = "2021"
 license = "Apache-2.0"
 name = "canbench-rs-macros"
 repository = "https://github.com/dfinity/canbench"
-version = "0.1.11"
+version = "0.1.12"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/canbench-rs/Cargo.toml
+++ b/canbench-rs/Cargo.toml
@@ -6,7 +6,7 @@ keywords = ["benchmark", "canister", "ic", "internet-computer", "perf"]
 license = "Apache-2.0"
 readme = "../README.md"
 repository = "https://github.com/dfinity/canbench"
-# NOTE: whenever this is updated, canbench-rs-macros below should also be updated.
+# NOTE: Update `canbench-rs-macros` version below when this changes.
 version = "0.1.12"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/canbench-rs/Cargo.toml
+++ b/canbench-rs/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "canbench-rs"
-# NOTE: whenever this is updated, canbench-rs-macros below should also be updated.
 description = "The rust library for `canbench`, the benchmarking framework for canisters on the Internet Computer."
 edition = "2021"
 keywords = ["benchmark", "canister", "ic", "internet-computer", "perf"]
 license = "Apache-2.0"
 readme = "../README.md"
 repository = "https://github.com/dfinity/canbench"
-version = "0.1.11"
+# NOTE: whenever this is updated, canbench-rs-macros below should also be updated.
+version = "0.1.12"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -15,7 +15,7 @@ version = "0.1.11"
 path = "src/lib.rs"
 
 [dependencies]
-canbench-rs-macros = { path = "../canbench-rs-macros", version = "0.1.11" }
+canbench-rs-macros = { path = "../canbench-rs-macros", version = "0.1.12" }
 candid.workspace = true
 ic-cdk.workspace = true
 serde.workspace = true


### PR DESCRIPTION
This PR bumps the version numbers from 0.1.11 to 0.1.12 across the project to ensure consistency between the main library, macros, and binary packages.

- Update version in `canbench-rs/Cargo.toml` and corresponding dependency comment.
- Update version in `canbench-rs-macros/Cargo.toml`.
- Update version string in tests and `canbench-bin/Cargo.toml`.
