### PR TITLE
ci: show summary in canbench report message

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,12 +3,14 @@ on: [pull_request]
 
 env:
   RUST_VERSION: 1.86.0
+  CARGO_TERM_COLOR: always # Force Cargo to use colors
+  TERM: xterm-256color
 
 jobs:
   build:
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest ]
+        os: [ubuntu-latest, macos-latest]
 
     runs-on: ${{ matrix.os }}
 
@@ -40,7 +42,7 @@ jobs:
         run: cargo clippy --tests --benches -- -D clippy::all
 
       - name: Test
-        run: cargo test --all-features -- --test-threads=1
+        run: cargo test --all-features --color always -- --color always --test-threads=1
         env:
           RUST_BACKTRACE: 1
 
@@ -132,11 +134,11 @@ jobs:
     name: ShellCheck
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - name: Run ShellCheck
-      uses: ludeeus/action-shellcheck@master
-      env:
-        SHELLCHECK_OPTS: -e SC1090 -e SC2119 -e SC1091
+      - uses: actions/checkout@v4
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@master
+        env:
+          SHELLCHECK_OPTS: -e SC1090 -e SC2119 -e SC1091
 
   upload-pr-number:
     runs-on: ubuntu-latest
@@ -156,12 +158,13 @@ jobs:
   checks-pass:
     # Always run this job!
     if: always()
-    needs: [
-      build,
-      shell-checks,
-      benchmark-fibonacci-example,
-      benchmark-btreemap-vs-hashmap-example
-    ]
+    needs:
+      [
+        build,
+        shell-checks,
+        benchmark-fibonacci-example,
+        benchmark-btreemap-vs-hashmap-example,
+      ]
     runs-on: ubuntu-latest
     steps:
       - name: check build result

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -22,14 +22,14 @@ jobs:
     name: conventional-pr-title:required
     runs-on: ubuntu-latest
     steps:
-        # Conventional commit patterns:
-        #   verb: description
-        #   verb!: description of breaking change
-        #   verb(scope): Description of change to $scope
-        #   verb(scope)!: Description of breaking change to $scope
-        # verb: feat, fix, ...
-        # scope: refers to the part of code being changed.  E.g. " (accounts)" or " (accounts,canisters)"
-        # !: Indicates that the PR contains a breaking change.
+      # Conventional commit patterns:
+      #   verb: description
+      #   verb!: description of breaking change
+      #   verb(scope): Description of change to $scope
+      #   verb(scope)!: Description of breaking change to $scope
+      # verb: feat, fix, ...
+      # scope: refers to the part of code being changed.  E.g. " (accounts)" or " (accounts,canisters)"
+      # !: Indicates that the PR contains a breaking change.
       - run: |
           if [[ "$TITLE" =~ ^(feat|fix|chore|build|ci|docs|style|refactor|perf|test)(\([-a-zA-Z0-9,]+\))?\!?\: ]]; then
               echo pass

--- a/scripts/ci_run_benchmark.sh
+++ b/scripts/ci_run_benchmark.sh
@@ -35,13 +35,13 @@ fi
 pushd "$CANISTER_PATH"
 canbench --less-verbose > $CANBENCH_OUTPUT
 if grep -q "(regress\|(improved by \|(new)" "$CANBENCH_OUTPUT"; then
-  UPDATED_MSG="**\`$CANBENCH_RESULTS_FILE\` is not up to date ❌**
+  UPDATED_MSG="**❌ \`$CANBENCH_RESULTS_FILE\` is not up to date**
   If the performance change is expected, run \`canbench --persist\` to save the updated benchmark results.";
 
   # canbench results file not up to date. Fail the job.
   echo "EXIT_STATUS=1" >> "$GITHUB_ENV"
 else
-  UPDATED_MSG="**\`$CANBENCH_RESULTS_FILE\` is up to date ✅**";
+  UPDATED_MSG="**✅ \`$CANBENCH_RESULTS_FILE\` is up to date**";
 
   # canbench results file is up to date. The job succeeds.
   echo "EXIT_STATUS=0" >> "$GITHUB_ENV"

--- a/scripts/ci_run_benchmark.sh
+++ b/scripts/ci_run_benchmark.sh
@@ -48,8 +48,12 @@ else
 fi
 popd
 
+# Get the latest commit hash
+commit_hash=$(git rev-parse HEAD)
+time=$(date -u +"%Y-%m-%d %H:%M:%S UTC")
 
-echo "# \`canbench\` 🏋 (dir: $CANISTER_PATH)" > "$COMMENT_MESSAGE_PATH"
+# Print output with correct formatting
+echo "# \`canbench\` 🏋 (dir: $CANISTER_PATH) $commit_hash $time" > "$COMMENT_MESSAGE_PATH"
 
 # Detect if there are performance changes relative to the main branch.
 if [ -f "$MAIN_BRANCH_RESULTS_FILE" ]; then
@@ -61,13 +65,19 @@ if [ -f "$MAIN_BRANCH_RESULTS_FILE" ]; then
   canbench --less-verbose --show-summary > "$CANBENCH_OUTPUT"
   popd
 
-  if grep -q "(regress\|(improved by" "${CANBENCH_OUTPUT}"; then
-    echo "**Significant performance change detected! ⚠️**
-    " >> "$COMMENT_MESSAGE_PATH"
-  else
-    echo "**No significant performance changes detected ✅**
-    " >> "$COMMENT_MESSAGE_PATH"
-  fi
+  # Append markers to individual benchmark results
+  awk '
+  /\(improved / { print $0, "🟢"; next }
+  /\(regressed / { print $0, "🔴"; next }
+  /\(new\)/ { print $0, "🟡"; next }
+  { print }
+  ' "$CANBENCH_OUTPUT" > "${CANBENCH_OUTPUT}.tmp" && mv "${CANBENCH_OUTPUT}.tmp" "$CANBENCH_OUTPUT"
+
+  # Add a top-level summary of detected performance changes
+  MESSAGE=""
+  grep -q "(improved " "${CANBENCH_OUTPUT}" && MESSAGE+="**🟢 Performance improvements detected! 🎉**\n"
+  grep -q "(regressed " "${CANBENCH_OUTPUT}" && MESSAGE+="**🔴 Performance regressions detected! 😱**\n"
+  echo -e "${MESSAGE:-**ℹ️ No significant performance changes detected 👍**}" >> "$COMMENT_MESSAGE_PATH"
 fi
 
 ## Add the output of canbench to the file.

--- a/scripts/ci_run_benchmark.sh
+++ b/scripts/ci_run_benchmark.sh
@@ -58,7 +58,7 @@ if [ -f "$MAIN_BRANCH_RESULTS_FILE" ]; then
 
   # Run canbench to compare result to main branch.
   pushd "$CANISTER_PATH"
-  canbench --less-verbose > "$CANBENCH_OUTPUT"
+  canbench --less-verbose --show-summary > "$CANBENCH_OUTPUT"
   popd
 
   if grep -q "(regress\|(improved by" "${CANBENCH_OUTPUT}"; then


### PR DESCRIPTION
This PR enhances the CI benchmark reporting by showing a summary message.

It also improves the canbench report header by including commit metadata and performance summary markers.
It was previously tested in [bitcoin-canister repo](https://github.com/dfinity/bitcoin-canister/pull/372#issuecomment-2687361621).

- Adjusts canbench command flags to display a summary
- Updates the CI script to include the latest commit hash and timestamp in the canbench report message and append summary markers for performance changes, [example](https://github.com/dfinity/canbench/pull/105#issuecomment-2862249363)
- Updates the CI workflow to enforce colored output and adjusts job dependency formatting