### PR TITLE
fix: downgrade ic-cdk to 0.17.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -959,26 +959,29 @@ dependencies = [
 
 [[package]]
 name = "ic-cdk"
-version = "0.18.0"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b11cc255410be6a7e47e1a756ea94c1f31a2397a79e696f6f7d207d5ebd3e144"
+checksum = "95a7344f41493cbf591f13ae9f90181076f808a83af799815c3074b19c693d2e"
 dependencies = [
  "candid",
+ "ic-cdk-executor",
  "ic-cdk-macros",
- "ic-error-types",
- "ic-management-canister-types",
  "ic0",
  "serde",
  "serde_bytes",
- "slotmap",
- "thiserror 2.0.12",
 ]
 
 [[package]]
-name = "ic-cdk-macros"
-version = "0.18.0"
+name = "ic-cdk-executor"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bab0b748bc4059f19abbd2c2609761ca6d6c731979f01148b49afcc4fe7a9f"
+checksum = "903057edd3d4ff4b3fe44a64eaee1ceb73f579ba29e3ded372b63d291d7c16c2"
+
+[[package]]
+name = "ic-cdk-macros"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84cbaa50fa36d3e0616114becf81faa95a099e0d60948ed6978f30f1c77399fd"
 dependencies = [
  "candid",
  "proc-macro2",
@@ -998,17 +1001,6 @@ dependencies = [
  "serde",
  "serde_bytes",
  "sha2",
-]
-
-[[package]]
-name = "ic-error-types"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be844216781d6f4a0853b5a8d63dee8d1b6ee0b9aef310d8c0cb82a6796d7072"
-dependencies = [
- "serde",
- "strum",
- "strum_macros",
 ]
 
 [[package]]
@@ -1042,9 +1034,9 @@ dependencies = [
 
 [[package]]
 name = "ic0"
-version = "0.24.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673a6b846467547f3fc61f95d246aadff03e368b53c931655300b9d1bd05a55a"
+checksum = "8de254dd67bbd58073e23dc1c8553ba12fa1dc610a19de94ad2bbcd0460c067f"
 
 [[package]]
 name = "ic_principal"
@@ -2119,15 +2111,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8347046d4ebd943127157b94d63abb990fcf729dc4e9978927fdf4ac3c998d06"
 dependencies = [
  "erased-serde",
-]
-
-[[package]]
-name = "slotmap"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbff4acf519f630b3a3ddcfaea6c06b42174d9a44bc70c620e9ed1649d58b82a"
-dependencies = [
- "version_check",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ clap = { version = "4.0.11", features = ["derive"] }
 colored = "2.0.4"
 flate2 = "1.0.28"
 hex = "0.4.3"
-ic-cdk = "0.18.0"
-ic-cdk-macros = "0.18.0"
+ic-cdk = "0.17.2"
+ic-cdk-macros = "0.17.2"
 proc-macro2 = "1.0"
 quote = "1.0"
 reqwest = { version = "0.11.23", features = [

--- a/canbench-rs/src/lib.rs
+++ b/canbench-rs/src/lib.rs
@@ -521,11 +521,11 @@ pub fn bench_fn<R>(f: impl FnOnce() -> R) -> BenchResult {
 
     if !is_tracing_enabled {
         let start_heap = heap_size();
-        let start_stable_memory = ic_cdk::stable::stable_size();
+        let start_stable_memory = ic_cdk::api::stable::stable_size();
         let start_instructions = instruction_count();
         f();
         let instructions = instruction_count() - start_instructions;
-        let stable_memory_increase = ic_cdk::stable::stable_size() - start_stable_memory;
+        let stable_memory_increase = ic_cdk::api::stable::stable_size() - start_stable_memory;
         let heap_increase = heap_size() - start_heap;
 
         let total = Measurement {
@@ -607,7 +607,7 @@ pub struct BenchScope {
 impl BenchScope {
     fn new(name: &'static str) -> Self {
         let start_heap = heap_size();
-        let start_stable_memory = ic_cdk::stable::stable_size();
+        let start_stable_memory = ic_cdk::api::stable::stable_size();
         let start_instructions = instruction_count();
 
         Self {
@@ -622,7 +622,7 @@ impl BenchScope {
 impl Drop for BenchScope {
     fn drop(&mut self) {
         let instructions = instruction_count() - self.start_instructions;
-        let stable_memory_increase = ic_cdk::stable::stable_size() - self.start_stable_memory;
+        let stable_memory_increase = ic_cdk::api::stable::stable_size() - self.start_stable_memory;
         let heap_increase = heap_size() - self.start_heap;
 
         SCOPES.with(|p| {

--- a/examples/btreemap_vs_hashmap/src/main.rs
+++ b/examples/btreemap_vs_hashmap/src/main.rs
@@ -30,7 +30,7 @@ fn pre_upgrade() {
     // Write to stable memory.
     #[cfg(feature = "canbench-rs")]
     let _p = canbench_rs::bench_scope("writing_to_stable_memory");
-    ic_cdk::stable::StableWriter::default()
+    ic_cdk::api::stable::StableWriter::default()
         .write(&bytes)
         .unwrap();
 }

--- a/tests/stable_memory/src/main.rs
+++ b/tests/stable_memory/src/main.rs
@@ -3,10 +3,10 @@ use canbench_rs::bench;
 #[bench]
 fn read_from_stable_memory() {
     let mut buf = [0; 10];
-    ic_cdk::stable::stable_read(0, &mut buf);
+    ic_cdk::api::stable::stable_read(0, &mut buf);
 
     // There should be one page in stable memory.
-    assert_eq!(ic_cdk::stable::stable_size(), 1);
+    assert_eq!(ic_cdk::api::stable::stable_size(), 1);
 
     // The `stable_memory.bin` specified in canbench.yml only has the first give bytes set.
     // The rest should be zero.


### PR DESCRIPTION
This PR downgrades ic-cdk to v0.17.2 since v0.18.0 has been yanked.