### PR TITLE
feat: add absolute delta columns for each metric to CSV report

### DIFF
--- a/canbench-bin/src/csv_file.rs
+++ b/canbench-bin/src/csv_file.rs
@@ -32,7 +32,7 @@ pub(crate) fn write(output_file: &PathBuf, data: &[Entry]) {
         let row = [
             entry.status.clone(),
             name.clone(),
-            // CSV report use full numbers
+            // CSV report uses full numbers
             entry.instructions.fmt_current(),
             entry.instructions.fmt_abs_delta(),
             entry.instructions.fmt_percent(),

--- a/canbench-bin/src/csv_file.rs
+++ b/canbench-bin/src/csv_file.rs
@@ -15,11 +15,14 @@ pub(crate) fn write(output_file: &PathBuf, data: &[Entry]) {
         "status",
         "name",
         "instructions",
-        "instructions change %",
+        "instructions Δ",
+        "instructions Δ%",
         "heap_increase",
-        "heap_increase change %",
+        "heap_increase Δ",
+        "heap_increase Δ%",
         "stable_memory_increase",
-        "stable_memory_increase change %",
+        "stable_memory_increase Δ",
+        "stable_memory_increase Δ%",
     ];
 
     writeln!(file, "{}", HEADERS.join(&DELIMITER.to_string())).expect("Failed to write CSV header");
@@ -29,12 +32,16 @@ pub(crate) fn write(output_file: &PathBuf, data: &[Entry]) {
         let row = [
             entry.status.clone(),
             name.clone(),
-            entry.instructions.fmt_current(), // CSV report use full numbers
-            entry.instructions.fmt_human_percent(),
+            // CSV report use full numbers
+            entry.instructions.fmt_current(),
+            entry.instructions.fmt_abs_delta(),
+            entry.instructions.fmt_percent(),
             entry.heap_increase.fmt_current(),
-            entry.heap_increase.fmt_human_percent(),
+            entry.heap_increase.fmt_abs_delta(),
+            entry.heap_increase.fmt_percent(),
             entry.stable_memory_increase.fmt_current(),
-            entry.stable_memory_increase.fmt_human_percent(),
+            entry.stable_memory_increase.fmt_abs_delta(),
+            entry.stable_memory_increase.fmt_percent(),
         ];
 
         writeln!(file, "{}", row.join(&DELIMITER.to_string()))

--- a/canbench-bin/src/data.rs
+++ b/canbench-bin/src/data.rs
@@ -1,4 +1,4 @@
-use crate::fmt::{fmt_human_percent, fmt_human_u64};
+use crate::fmt::{fmt_human_u64, fmt_percent};
 use canbench_rs::{BenchResult, Measurement};
 use std::collections::BTreeMap;
 
@@ -85,9 +85,12 @@ impl Values {
         self.current().map_or_else(String::new, fmt_human_u64)
     }
 
-    pub(crate) fn fmt_human_percent(&self) -> String {
-        self.percent_diff()
-            .map_or_else(String::new, fmt_human_percent)
+    pub(crate) fn fmt_abs_delta(&self) -> String {
+        self.abs_delta().map_or_else(String::new, |v| v.to_string())
+    }
+
+    pub(crate) fn fmt_percent(&self) -> String {
+        self.percent_diff().map_or_else(String::new, fmt_percent)
     }
 
     pub(crate) fn status(&self, noise_threshold: f64) -> Change {

--- a/canbench-bin/src/fmt.rs
+++ b/canbench-bin/src/fmt.rs
@@ -27,7 +27,7 @@ pub(crate) fn fmt_human_i64(value: i64) -> String {
     }
 }
 
-pub(crate) fn fmt_human_percent(value: f64) -> String {
+pub(crate) fn fmt_percent(value: f64) -> String {
     if value.abs() < 0.01 {
         format!("{:.2}%", value)
     } else {

--- a/canbench-bin/src/summary.rs
+++ b/canbench-bin/src/summary.rs
@@ -1,5 +1,5 @@
 use crate::data::{Change, Entry, Values};
-use crate::fmt::{fmt_human_i64, fmt_human_percent};
+use crate::fmt::{fmt_human_i64, fmt_percent};
 use std::f64;
 
 pub(crate) fn print_summary(data: &Vec<Entry>, noise_threshold: f64) {
@@ -71,12 +71,7 @@ where
     }
 
     if !percent_diffs.is_empty() {
-        print_range(
-            "    change %:",
-            &percent_diffs,
-            fmt_human_percent,
-            percentile_f64,
-        );
+        print_range("    change %:", &percent_diffs, fmt_percent, percentile_f64);
     } else {
         println!("    change %: n/a");
     }

--- a/canbench-bin/src/table.rs
+++ b/canbench-bin/src/table.rs
@@ -77,7 +77,7 @@ pub(crate) fn print_table(data: &[Entry]) {
         let row = [
             entry.status.clone(),
             name,
-            // Table report use short numbers
+            // Table report uses short numbers
             entry.instructions.fmt_human_current(),
             entry.instructions.fmt_percent(),
             entry.heap_increase.fmt_human_current(),

--- a/canbench-bin/src/table.rs
+++ b/canbench-bin/src/table.rs
@@ -77,12 +77,13 @@ pub(crate) fn print_table(data: &[Entry]) {
         let row = [
             entry.status.clone(),
             name,
-            entry.instructions.fmt_human_current(), // Table report use short numbers
-            entry.instructions.fmt_human_percent(),
+            // Table report use short numbers
+            entry.instructions.fmt_human_current(),
+            entry.instructions.fmt_percent(),
             entry.heap_increase.fmt_human_current(),
-            entry.heap_increase.fmt_human_percent(),
+            entry.heap_increase.fmt_percent(),
             entry.stable_memory_increase.fmt_human_current(),
-            entry.stable_memory_increase.fmt_human_percent(),
+            entry.stable_memory_increase.fmt_percent(),
         ];
         rows.push(row);
     }

--- a/examples/btreemap_vs_hashmap/canbench_results.csv
+++ b/examples/btreemap_vs_hashmap/canbench_results.csv
@@ -1,6 +1,6 @@
-status,name,instructions,instructions change %,heap_increase,heap_increase change %,stable_memory_increase,stable_memory_increase change %
-,insert_users,2558172165,-0.00%,871,-0.11%,0,0.00%
-,pre_upgrade_bench,438872727,-0.00%,519,0.00%,184,0.00%
-,pre_upgrade_bench::serialize_state,423939828,-0.00%,519,0.00%,0,0.00%
-,pre_upgrade_bench::writing_to_stable_memory,14930542,0.00%,0,0.00%,184,0.00%
-,remove_users,2109136823,0.00%,0,0.00%,0,0.00%
+status,name,instructions,instructions Δ,instructions Δ%,heap_increase,heap_increase Δ,heap_increase Δ%,stable_memory_increase,stable_memory_increase Δ,stable_memory_increase Δ%
+,insert_users,2558172165,0,0.00%,871,0,0.00%,0,0,0.00%
+,pre_upgrade_bench,438872727,0,0.00%,519,0,0.00%,184,0,0.00%
+,pre_upgrade_bench::serialize_state,423939828,0,0.00%,519,0,0.00%,0,0,0.00%
+,pre_upgrade_bench::writing_to_stable_memory,14930542,0,0.00%,0,0,0.00%,184,0,0.00%
+,remove_users,2109136823,0,0.00%,0,0,0.00%,0,0,0.00%

--- a/examples/fibonacci/canbench_results.csv
+++ b/examples/fibonacci/canbench_results.csv
@@ -1,6 +1,6 @@
-status,name,instructions,instructions change %,heap_increase,heap_increase change %,stable_memory_increase,stable_memory_increase change %
-,fibonacci_20,726,0.00%,0,0.00%,0,0.00%
-,fibonacci_45,1301,0.00%,0,0.00%,0,0.00%
-,fibonacci_8a,450,0.00%,0,0.00%,0,0.00%
-,fibonacci_8b,207,0.00%,0,0.00%,0,0.00%
-,fibonacci_8c,391,0.00%,0,0.00%,0,0.00%
+status,name,instructions,instructions Δ,instructions Δ%,heap_increase,heap_increase Δ,heap_increase Δ%,stable_memory_increase,stable_memory_increase Δ,stable_memory_increase Δ%
+,fibonacci_20,726,0,0.00%,0,0,0.00%,0,0,0.00%
+,fibonacci_45,1301,0,0.00%,0,0,0.00%,0,0,0.00%
+,fibonacci_8a,450,0,0.00%,0,0,0.00%,0,0,0.00%
+,fibonacci_8b,207,0,0.00%,0,0,0.00%,0,0,0.00%
+,fibonacci_8c,391,0,0.00%,0,0,0.00%,0,0,0.00%


### PR DESCRIPTION
This PR adds absolute delta columns for each metric to the CSV report.

The summary remains concise for a quick overview, while the CSV report now includes detailed information: current value, absolute change, and relative change for each metric.