### PR TITLE
feat: add max displayed rows limit to the summary table

### DIFF
--- a/canbench-bin/src/lib.rs
+++ b/canbench-bin/src/lib.rs
@@ -36,7 +36,7 @@ const POCKET_IC_LINUX_SHA: &str =
 const POCKET_IC_MAC_SHA: &str = "27bb9594e498171d2fffadf6e1e144e58ed3f5854d151ff8431d9dc298b7951e";
 
 /// The maximum number of rows to display in the summary table.
-const MAX_DISPLAYED_ROWS: usize = 50;
+const MAX_DISPLAYED_ROWS: usize = 2;
 
 /// Runs the benchmarks on the canister available in the provided `canister_wasm_path`.
 #[allow(clippy::too_many_arguments)]

--- a/canbench-bin/src/lib.rs
+++ b/canbench-bin/src/lib.rs
@@ -147,7 +147,7 @@ pub fn run_benchmarks(
         if !filtered.is_empty() {
             println!();
             println!("Only significant changes:");
-            table::print_table(&filtered, MAX_DISPLAYED_ROWS);
+            table::print_table(&mut std::io::stdout(), &filtered, MAX_DISPLAYED_ROWS).unwrap();
             println!();
             println!("---------------------------------------------------");
         }

--- a/canbench-bin/src/lib.rs
+++ b/canbench-bin/src/lib.rs
@@ -144,7 +144,8 @@ pub fn run_benchmarks(
         if !filtered.is_empty() {
             println!();
             println!("Only significant changes:");
-            table::print_table(&filtered);
+            const MAX_DISPLAYED_ROWS: usize = 50;
+            table::print_table(&filtered, MAX_DISPLAYED_ROWS);
             println!();
             println!("---------------------------------------------------");
         }

--- a/canbench-bin/src/lib.rs
+++ b/canbench-bin/src/lib.rs
@@ -36,7 +36,7 @@ const POCKET_IC_LINUX_SHA: &str =
 const POCKET_IC_MAC_SHA: &str = "27bb9594e498171d2fffadf6e1e144e58ed3f5854d151ff8431d9dc298b7951e";
 
 /// The maximum number of rows to display in the summary table.
-const MAX_DISPLAYED_ROWS: usize = 2;
+const MAX_DISPLAYED_ROWS: usize = 50;
 
 /// Runs the benchmarks on the canister available in the provided `canister_wasm_path`.
 #[allow(clippy::too_many_arguments)]

--- a/canbench-bin/src/lib.rs
+++ b/canbench-bin/src/lib.rs
@@ -35,6 +35,9 @@ const POCKET_IC_LINUX_SHA: &str =
     "327346b681f0c03f1eb12e8da17a1ab8d044f31b2a1cbaad4546db9dbf73caf4";
 const POCKET_IC_MAC_SHA: &str = "27bb9594e498171d2fffadf6e1e144e58ed3f5854d151ff8431d9dc298b7951e";
 
+/// The maximum number of rows to display in the summary table.
+const MAX_DISPLAYED_ROWS: usize = 50;
+
 /// Runs the benchmarks on the canister available in the provided `canister_wasm_path`.
 #[allow(clippy::too_many_arguments)]
 pub fn run_benchmarks(
@@ -144,7 +147,6 @@ pub fn run_benchmarks(
         if !filtered.is_empty() {
             println!();
             println!("Only significant changes:");
-            const MAX_DISPLAYED_ROWS: usize = 50;
             table::print_table(&filtered, MAX_DISPLAYED_ROWS);
             println!();
             println!("---------------------------------------------------");

--- a/canbench-bin/src/table.rs
+++ b/canbench-bin/src/table.rs
@@ -91,7 +91,7 @@ pub(crate) fn print_table(data: &[Entry], max_displayed_rows: usize) {
     let total_rows = rows.len();
 
     // Apply row limit and add omitted indicator if needed
-    if total_rows > max_displayed_rows && max_displayed_rows >= 3 {
+    if total_rows > max_displayed_rows {
         let half_limit = max_displayed_rows / 2;
         let omitted_count = total_rows - max_displayed_rows;
 

--- a/canbench-bin/src/table.rs
+++ b/canbench-bin/src/table.rs
@@ -71,7 +71,7 @@ pub(crate) fn print_table(data: &[Entry], max_displayed_rows: usize) {
         "status", "name", "ins", "ins Δ%", "HI", "HI Δ%", "SMI", "SMI Δ%",
     ];
 
-    let mut rows: Vec<Vec<String>> = data
+    let mut rows: Vec<_> = data
         .iter()
         .map(|entry| {
             vec![
@@ -110,7 +110,7 @@ pub(crate) fn print_table(data: &[Entry], max_displayed_rows: usize) {
     }
 
     // Calculate max column widths after limiting and adding the indicator
-    let mut col_widths: Vec<usize> = columns.iter().map(|h| h.len()).collect();
+    let mut col_widths: Vec<_> = columns.iter().map(|h| h.len()).collect();
     for row in &rows {
         for (i, cell) in row.iter().enumerate() {
             col_widths[i] = col_widths[i].max(cell.len());

--- a/canbench-bin/src/table.rs
+++ b/canbench-bin/src/table.rs
@@ -104,7 +104,8 @@ pub(crate) fn print_table(data: &[Entry], max_displayed_rows: usize) {
         omitted_row[1] = format!("({} omitted)", omitted_count); // "name" column
         limited_rows.push(omitted_row);
 
-        limited_rows.extend_from_slice(&rows[total_rows - (max_displayed_rows - half_limit - 1)..]);
+        let suffix_rows = total_rows - half_limit - 1;
+        limited_rows.extend_from_slice(&rows[total_rows - suffix_rows..]);
         rows = limited_rows;
     }
 

--- a/canbench-bin/src/table.rs
+++ b/canbench-bin/src/table.rs
@@ -133,8 +133,8 @@ pub(crate) fn print_table(data: &[Entry], max_displayed_rows: usize) {
 
         // Print omitted rows indicator
         let mut omitted_row = vec!["".to_string(); columns.len()];
-        omitted_row[0] = "...".to_string(); // Set in "status" column
-        omitted_row[1] = format!("({} omitted)", total_rows - max_displayed_rows); // Set in "name" column
+        omitted_row[0] = "...".to_string(); // "status" column
+        omitted_row[1] = format!("({} omitted)", total_rows - max_displayed_rows); // "name" column
         print_row(&omitted_row);
 
         for row in &rows[total_rows - half_limit..] {

--- a/canbench-bin/src/table.rs
+++ b/canbench-bin/src/table.rs
@@ -1,4 +1,5 @@
 use crate::data::{Change, Entry};
+use std::io::{self, Write};
 
 pub(crate) fn filter_entries(data: &[Entry], noise_threshold: f64) -> Vec<Entry> {
     let mut filtered: Vec<Entry> = data
@@ -66,18 +67,20 @@ pub(crate) fn filter_entries(data: &[Entry], noise_threshold: f64) -> Vec<Entry>
     filtered
 }
 
-pub(crate) fn print_table(data: &[Entry], max_displayed_rows: usize) {
+pub(crate) fn print_table<W: Write>(
+    writer: &mut W,
+    data: &[Entry],
+    max_displayed_rows: usize,
+) -> io::Result<()> {
     let columns = [
         "status", "name", "ins", "ins Δ%", "HI", "HI Δ%", "SMI", "SMI Δ%",
     ];
-
     let mut rows: Vec<_> = data
         .iter()
         .map(|entry| {
             vec![
                 entry.status.clone(),
                 entry.benchmark.full_name(),
-                // Table report uses short numbers
                 entry.instructions.fmt_human_current(),
                 entry.instructions.fmt_percent(),
                 entry.heap_increase.fmt_human_current(),
@@ -90,27 +93,32 @@ pub(crate) fn print_table(data: &[Entry], max_displayed_rows: usize) {
 
     let total_rows = rows.len();
 
-    // Apply row limit and add omitted indicator if needed
-    let omitted_count = total_rows as isize - max_displayed_rows as isize + 1;
-    if total_rows > max_displayed_rows && omitted_count >= 2 {
+    if total_rows > max_displayed_rows {
+        let omitted_count = total_rows - max_displayed_rows;
         let head_rows = max_displayed_rows / 2;
-        let tail_rows = max_displayed_rows - head_rows - 1;
-        let omitted_count = total_rows - head_rows - tail_rows;
+        let tail_rows = max_displayed_rows - head_rows;
 
         let mut limited_rows = Vec::new();
-        limited_rows.extend_from_slice(&rows[..head_rows]);
+        if head_rows > 0 {
+            limited_rows.extend_from_slice(&rows[..head_rows]);
+        }
 
-        // Insert omitted rows indicator
         let mut omitted_row = vec!["".to_string(); columns.len()];
-        omitted_row[0] = "...".to_string(); // "status" column
-        omitted_row[1] = format!("({} rows omitted)", omitted_count); // "name" column
+        omitted_row[0] = "...".to_string();
+        omitted_row[1] = format!(
+            "({} row{} omitted)",
+            omitted_count,
+            if omitted_count == 1 { "" } else { "s" }
+        );
         limited_rows.push(omitted_row);
 
-        limited_rows.extend_from_slice(&rows[total_rows - tail_rows..]);
+        if tail_rows > 0 {
+            limited_rows.extend_from_slice(&rows[total_rows - tail_rows..]);
+        }
+
         rows = limited_rows;
     }
 
-    // Calculate max column widths after limiting and adding the indicator
     let mut col_widths: Vec<_> = columns.iter().map(|h| h.len()).collect();
     for row in &rows {
         for (i, cell) in row.iter().enumerate() {
@@ -118,33 +126,136 @@ pub(crate) fn print_table(data: &[Entry], max_displayed_rows: usize) {
         }
     }
 
-    // Helper to print a row
-    let print_row = |row: &[String]| {
-        print!("|");
+    let print_row = |writer: &mut W, row: &[String]| -> io::Result<()> {
+        write!(writer, "|")?;
         for (i, cell) in row.iter().enumerate() {
             let width = col_widths[i];
             match i {
-                0 => print!(" {:^width$} ", cell, width = width), // Center "status"
-                1 => print!(" {:<width$} ", cell, width = width), // Left-align "name"
-                _ => print!(" {:>width$} ", cell, width = width), // Right-align numbers
+                0 => write!(writer, " {:^width$} |", cell, width = width)?,
+                1 => write!(writer, " {:<width$} |", cell, width = width)?,
+                _ => write!(writer, " {:>width$} |", cell, width = width)?,
             }
-            print!("|");
         }
-        println!();
+        writeln!(writer)
     };
 
-    // Print header
-    print_row(&columns.iter().map(|s| s.to_string()).collect::<Vec<_>>());
-
-    // Print separator
-    print!("|");
+    print_row(
+        writer,
+        &columns.iter().map(|s| s.to_string()).collect::<Vec<_>>(),
+    )?;
+    write!(writer, "|")?;
     for width in &col_widths {
-        print!("{}|", "-".repeat(width + 2));
+        write!(writer, "{}|", "-".repeat(width + 2))?;
     }
-    println!();
+    writeln!(writer)?;
 
-    // Print data rows
     for row in &rows {
-        print_row(row);
+        print_row(writer, row)?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::data::{Benchmark, Values};
+
+    fn create_entry(name: &str) -> Entry {
+        Entry {
+            status: "".to_string(),
+            benchmark: Benchmark::new(name, None),
+            instructions: Values::new(Some(9_000_000), Some(10_000_000)),
+            heap_increase: Values::new(Some(0), None),
+            stable_memory_increase: Values::new(Some(0), None),
+        }
+    }
+
+    fn run_table_test_case(max_displayed_rows: usize, expected_output: &str) {
+        let entries: Vec<Entry> = (1..=5)
+            .map(|i| create_entry(&format!("bench_{}", i)))
+            .collect();
+
+        let mut output = Vec::new();
+        print_table(&mut output, &entries, max_displayed_rows).unwrap();
+
+        let output_str = String::from_utf8_lossy(&output);
+        assert_eq!(
+            output_str, expected_output,
+            "Unexpected output with max_displayed_rows = {}:\n{}",
+            max_displayed_rows, output_str
+        );
+    }
+
+    #[test]
+    fn test_print_table_variants() {
+        let test_cases = [
+            (
+                0,
+                "\
+| status | name             | ins |  ins Δ% | HI |  HI Δ% | SMI |  SMI Δ% |
+|--------|------------------|-----|---------|----|--------|-----|---------|
+|  ...   | (5 rows omitted) |     |         |    |        |     |         |
+",
+            ),
+            (
+                1,
+                "\
+| status | name             |   ins |  ins Δ% | HI |  HI Δ% | SMI |  SMI Δ% |
+|--------|------------------|-------|---------|----|--------|-----|---------|
+|  ...   | (4 rows omitted) |       |         |    |        |     |         |
+|        | bench_5          | 9.00M | -10.00% |  0 |        |   0 |         |
+",
+            ),
+            (
+                2,
+                "\
+| status | name             |   ins |  ins Δ% | HI |  HI Δ% | SMI |  SMI Δ% |
+|--------|------------------|-------|---------|----|--------|-----|---------|
+|        | bench_1          | 9.00M | -10.00% |  0 |        |   0 |         |
+|  ...   | (3 rows omitted) |       |         |    |        |     |         |
+|        | bench_5          | 9.00M | -10.00% |  0 |        |   0 |         |
+",
+            ),
+            (
+                3,
+                "\
+| status | name             |   ins |  ins Δ% | HI |  HI Δ% | SMI |  SMI Δ% |
+|--------|------------------|-------|---------|----|--------|-----|---------|
+|        | bench_1          | 9.00M | -10.00% |  0 |        |   0 |         |
+|  ...   | (2 rows omitted) |       |         |    |        |     |         |
+|        | bench_4          | 9.00M | -10.00% |  0 |        |   0 |         |
+|        | bench_5          | 9.00M | -10.00% |  0 |        |   0 |         |
+",
+            ),
+            (
+                4,
+                "\
+| status | name            |   ins |  ins Δ% | HI |  HI Δ% | SMI |  SMI Δ% |
+|--------|-----------------|-------|---------|----|--------|-----|---------|
+|        | bench_1         | 9.00M | -10.00% |  0 |        |   0 |         |
+|        | bench_2         | 9.00M | -10.00% |  0 |        |   0 |         |
+|  ...   | (1 row omitted) |       |         |    |        |     |         |
+|        | bench_4         | 9.00M | -10.00% |  0 |        |   0 |         |
+|        | bench_5         | 9.00M | -10.00% |  0 |        |   0 |         |
+",
+            ),
+            (
+                5,
+                "\
+| status | name    |   ins |  ins Δ% | HI |  HI Δ% | SMI |  SMI Δ% |
+|--------|---------|-------|---------|----|--------|-----|---------|
+|        | bench_1 | 9.00M | -10.00% |  0 |        |   0 |         |
+|        | bench_2 | 9.00M | -10.00% |  0 |        |   0 |         |
+|        | bench_3 | 9.00M | -10.00% |  0 |        |   0 |         |
+|        | bench_4 | 9.00M | -10.00% |  0 |        |   0 |         |
+|        | bench_5 | 9.00M | -10.00% |  0 |        |   0 |         |
+",
+            ),
+        ];
+
+        for (max_displayed_rows, expected_output) in test_cases {
+            run_table_test_case(max_displayed_rows, expected_output);
+        }
     }
 }

--- a/canbench-bin/src/table.rs
+++ b/canbench-bin/src/table.rs
@@ -101,7 +101,7 @@ pub(crate) fn print_table(data: &[Entry], max_displayed_rows: usize) {
         // Insert omitted rows indicator
         let mut omitted_row = vec!["".to_string(); columns.len()];
         omitted_row[0] = "...".to_string(); // "status" column
-        omitted_row[1] = format!("({} omitted)", omitted_count); // "name" column
+        omitted_row[1] = format!("({} rows omitted)", omitted_count); // "name" column
         limited_rows.push(omitted_row);
 
         let suffix_rows = total_rows - half_limit - 1;

--- a/canbench-bin/src/table.rs
+++ b/canbench-bin/src/table.rs
@@ -91,9 +91,9 @@ pub(crate) fn print_table(data: &[Entry], max_displayed_rows: usize) {
     let total_rows = rows.len();
 
     // Apply row limit and add omitted indicator if needed
-    if total_rows > max_displayed_rows {
+    let omitted_count = total_rows as isize - max_displayed_rows as isize;
+    if omitted_count > 2 {
         let half_limit = max_displayed_rows / 2;
-        let omitted_count = total_rows - max_displayed_rows;
 
         let mut limited_rows = Vec::new();
         limited_rows.extend_from_slice(&rows[..half_limit]);

--- a/canbench-bin/src/table.rs
+++ b/canbench-bin/src/table.rs
@@ -91,12 +91,14 @@ pub(crate) fn print_table(data: &[Entry], max_displayed_rows: usize) {
     let total_rows = rows.len();
 
     // Apply row limit and add omitted indicator if needed
-    let omitted_count = total_rows as isize - max_displayed_rows as isize;
-    if omitted_count > 2 {
-        let half_limit = max_displayed_rows / 2;
+    let omitted_count = total_rows as isize - max_displayed_rows as isize + 1;
+    if total_rows > max_displayed_rows && omitted_count >= 2 {
+        let head_rows = max_displayed_rows / 2;
+        let tail_rows = max_displayed_rows - head_rows - 1;
+        let omitted_count = total_rows - head_rows - tail_rows;
 
         let mut limited_rows = Vec::new();
-        limited_rows.extend_from_slice(&rows[..half_limit]);
+        limited_rows.extend_from_slice(&rows[..head_rows]);
 
         // Insert omitted rows indicator
         let mut omitted_row = vec!["".to_string(); columns.len()];
@@ -104,8 +106,7 @@ pub(crate) fn print_table(data: &[Entry], max_displayed_rows: usize) {
         omitted_row[1] = format!("({} rows omitted)", omitted_count); // "name" column
         limited_rows.push(omitted_row);
 
-        let suffix_rows = total_rows - half_limit - 1;
-        limited_rows.extend_from_slice(&rows[total_rows - suffix_rows..]);
+        limited_rows.extend_from_slice(&rows[total_rows - tail_rows..]);
         rows = limited_rows;
     }
 


### PR DESCRIPTION
This PR improves summary readability by adding `max_displayed_rows` limit to the summary table.

Example:
```
---------------------------------------------------

Only significant changes:
| status | name             |   ins |  ins Δ% | HI |  HI Δ% | SMI |  SMI Δ% |
|--------|------------------|-------|---------|----|--------|-----|---------|
|        | bench_1          | 9.00M | -10.00% |  0 |        |   0 |         |
|  ...   | (3 rows omitted) |       |         |    |        |     |         |
|        | bench_5          | 9.00M | -10.00% |  0 |        |   0 |         |

---------------------------------------------------
```