### PR TITLE
feat: add numeric IDs for benchmark scopes for better performance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -279,6 +279,7 @@ dependencies = [
 name = "canbench-rs-macros"
 version = "0.1.14"
 dependencies = [
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -2264,6 +2265,7 @@ name = "tests"
 version = "0.1.0"
 dependencies = [
  "canbench-rs",
+ "canbench-rs-macros",
  "candid",
  "ic-cdk",
  "ic-cdk-macros",

--- a/canbench-bin/tests/expected/reports_repeated_scope_in_existing_benchmark.txt
+++ b/canbench-bin/tests/expected/reports_repeated_scope_in_existing_benchmark.txt
@@ -6,10 +6,10 @@ Benchmark: bench_repeated_scope_exists
     heap_increase: 0 pages (no change)
     stable_memory_increase: 0 pages (no change)
 
-  scope_1 (scope):
-    instructions: 8124 (regressed by 915.50%)
-    heap_increase: 0 pages (improved by 100.00%)
-    stable_memory_increase: 0 pages (no change)
+  some_scope1 (scope):
+    instructions: 8124 (new)
+    heap_increase: 0 pages (new)
+    stable_memory_increase: 0 pages (new)
 
 ---------------------------------------------------
 
@@ -35,9 +35,9 @@ Summary:
 ---------------------------------------------------
 
 Only significant changes:
-| status | name                                 |    ins |   ins Δ% | HI |    HI Δ% | SMI |  SMI Δ% |
-|--------|--------------------------------------|--------|----------|----|----------|-----|---------|
-|   +    | bench_repeated_scope_exists          | 14.95K |    +inf% |  0 |    0.00% |   0 |   0.00% |
-|  +/-   | bench_repeated_scope_exists::scope_1 |  8.12K | +915.50% |  0 | -100.00% |   0 |   0.00% |
+| status | name                                     |    ins |  ins Δ% | HI |  HI Δ% | SMI |  SMI Δ% |
+|--------|------------------------------------------|--------|---------|----|--------|-----|---------|
+|   +    | bench_repeated_scope_exists              | 14.95K |   +inf% |  0 |  0.00% |   0 |   0.00% |
+|  new   | bench_repeated_scope_exists::some_scope1 |  8.12K |         |  0 |        |   0 |         |
 
 ---------------------------------------------------

--- a/canbench-bin/tests/expected/reports_repeated_scope_in_existing_benchmark.txt
+++ b/canbench-bin/tests/expected/reports_repeated_scope_in_existing_benchmark.txt
@@ -2,12 +2,12 @@
 
 Benchmark: bench_repeated_scope_exists
   total:
-    instructions: 21.60 K (regressed from 0)
+    instructions: 16.93 K (regressed from 0)
     heap_increase: 0 pages (no change)
     stable_memory_increase: 0 pages (no change)
 
   scope_1 (scope):
-    instructions: 11.41 K (regressed by 1326.25%)
+    instructions: 8124 (regressed by 915.50%)
     heap_increase: 0 pages (improved by 100.00%)
     stable_memory_increase: 0 pages (no change)
 
@@ -17,7 +17,7 @@ Summary:
   instructions:
     status:   Regressions detected! 🔴
     counts:   [total 1 | new 0 | improved 0 | regressed 1 | unchanged 0]
-    change:   [min +21.60K | med +21.60K | max +21.60K]
+    change:   [min +16.93K | med +16.93K | max +16.93K]
     change %: [min +inf% | med +inf% | max +inf%]
 
   heap_increase:
@@ -35,9 +35,9 @@ Summary:
 ---------------------------------------------------
 
 Only significant changes:
-| status | name                                 |    ins |    ins Δ% | HI |    HI Δ% | SMI |  SMI Δ% |
-|--------|--------------------------------------|--------|-----------|----|----------|-----|---------|
-|   +    | bench_repeated_scope_exists          | 21.60K |     +inf% |  0 |    0.00% |   0 |   0.00% |
-|  +/-   | bench_repeated_scope_exists::scope_1 | 11.41K | +1326.25% |  0 | -100.00% |   0 |   0.00% |
+| status | name                                 |    ins |   ins Δ% | HI |    HI Δ% | SMI |  SMI Δ% |
+|--------|--------------------------------------|--------|----------|----|----------|-----|---------|
+|   +    | bench_repeated_scope_exists          | 16.93K |    +inf% |  0 |    0.00% |   0 |   0.00% |
+|  +/-   | bench_repeated_scope_exists::scope_1 |  8.12K | +915.50% |  0 | -100.00% |   0 |   0.00% |
 
 ---------------------------------------------------

--- a/canbench-bin/tests/expected/reports_repeated_scope_in_existing_benchmark.txt
+++ b/canbench-bin/tests/expected/reports_repeated_scope_in_existing_benchmark.txt
@@ -2,12 +2,12 @@
 
 Benchmark: bench_repeated_scope_exists
   total:
-    instructions: 16.48 K (regressed from 0)
+    instructions: 21.60 K (regressed from 0)
     heap_increase: 0 pages (no change)
     stable_memory_increase: 0 pages (no change)
 
   scope_1 (scope):
-    instructions: 8124 (regressed by 915.50%)
+    instructions: 11.41 K (regressed by 1326.25%)
     heap_increase: 0 pages (improved by 100.00%)
     stable_memory_increase: 0 pages (no change)
 
@@ -17,7 +17,7 @@ Summary:
   instructions:
     status:   Regressions detected! 🔴
     counts:   [total 1 | new 0 | improved 0 | regressed 1 | unchanged 0]
-    change:   [min +16.48K | med +16.48K | max +16.48K]
+    change:   [min +21.60K | med +21.60K | max +21.60K]
     change %: [min +inf% | med +inf% | max +inf%]
 
   heap_increase:
@@ -35,9 +35,9 @@ Summary:
 ---------------------------------------------------
 
 Only significant changes:
-| status | name                                 |    ins |   ins Δ% | HI |    HI Δ% | SMI |  SMI Δ% |
-|--------|--------------------------------------|--------|----------|----|----------|-----|---------|
-|   +    | bench_repeated_scope_exists          | 16.48K |    +inf% |  0 |    0.00% |   0 |   0.00% |
-|  +/-   | bench_repeated_scope_exists::scope_1 |  8.12K | +915.50% |  0 | -100.00% |   0 |   0.00% |
+| status | name                                 |    ins |    ins Δ% | HI |    HI Δ% | SMI |  SMI Δ% |
+|--------|--------------------------------------|--------|-----------|----|----------|-----|---------|
+|   +    | bench_repeated_scope_exists          | 21.60K |     +inf% |  0 |    0.00% |   0 |   0.00% |
+|  +/-   | bench_repeated_scope_exists::scope_1 | 11.41K | +1326.25% |  0 | -100.00% |   0 |   0.00% |
 
 ---------------------------------------------------

--- a/canbench-bin/tests/expected/reports_repeated_scope_in_existing_benchmark.txt
+++ b/canbench-bin/tests/expected/reports_repeated_scope_in_existing_benchmark.txt
@@ -2,7 +2,7 @@
 
 Benchmark: bench_repeated_scope_exists
   total:
-    instructions: 16.93 K (regressed from 0)
+    instructions: 14.95 K (regressed from 0)
     heap_increase: 0 pages (no change)
     stable_memory_increase: 0 pages (no change)
 
@@ -17,7 +17,7 @@ Summary:
   instructions:
     status:   Regressions detected! 🔴
     counts:   [total 1 | new 0 | improved 0 | regressed 1 | unchanged 0]
-    change:   [min +16.93K | med +16.93K | max +16.93K]
+    change:   [min +14.95K | med +14.95K | max +14.95K]
     change %: [min +inf% | med +inf% | max +inf%]
 
   heap_increase:
@@ -37,7 +37,7 @@ Summary:
 Only significant changes:
 | status | name                                 |    ins |   ins Δ% | HI |    HI Δ% | SMI |  SMI Δ% |
 |--------|--------------------------------------|--------|----------|----|----------|-----|---------|
-|   +    | bench_repeated_scope_exists          | 16.93K |    +inf% |  0 |    0.00% |   0 |   0.00% |
+|   +    | bench_repeated_scope_exists          | 14.95K |    +inf% |  0 |    0.00% |   0 |   0.00% |
 |  +/-   | bench_repeated_scope_exists::scope_1 |  8.12K | +915.50% |  0 | -100.00% |   0 |   0.00% |
 
 ---------------------------------------------------

--- a/canbench-bin/tests/expected/reports_repeated_scope_in_new_benchmark.txt
+++ b/canbench-bin/tests/expected/reports_repeated_scope_in_new_benchmark.txt
@@ -2,7 +2,7 @@
 
 Benchmark: bench_repeated_scope_new (new)
   total:
-    instructions: 16.93 K (new)
+    instructions: 14.95 K (new)
     heap_increase: 0 pages (new)
     stable_memory_increase: 0 pages (new)
 
@@ -37,7 +37,7 @@ Summary:
 Only significant changes:
 | status | name                              |    ins |  ins Δ% | HI |  HI Δ% | SMI |  SMI Δ% |
 |--------|-----------------------------------|--------|---------|----|--------|-----|---------|
-|  new   | bench_repeated_scope_new          | 16.93K |         |  0 |        |   0 |         |
+|  new   | bench_repeated_scope_new          | 14.95K |         |  0 |        |   0 |         |
 |  new   | bench_repeated_scope_new::scope_1 |  8.12K |         |  0 |        |   0 |         |
 
 ---------------------------------------------------

--- a/canbench-bin/tests/expected/reports_repeated_scope_in_new_benchmark.txt
+++ b/canbench-bin/tests/expected/reports_repeated_scope_in_new_benchmark.txt
@@ -2,12 +2,12 @@
 
 Benchmark: bench_repeated_scope_new (new)
   total:
-    instructions: 21.60 K (new)
+    instructions: 16.93 K (new)
     heap_increase: 0 pages (new)
     stable_memory_increase: 0 pages (new)
 
   scope_1 (scope):
-    instructions: 11.41 K (new)
+    instructions: 8124 (new)
     heap_increase: 0 pages (new)
     stable_memory_increase: 0 pages (new)
 
@@ -37,7 +37,7 @@ Summary:
 Only significant changes:
 | status | name                              |    ins |  ins Δ% | HI |  HI Δ% | SMI |  SMI Δ% |
 |--------|-----------------------------------|--------|---------|----|--------|-----|---------|
-|  new   | bench_repeated_scope_new          | 21.60K |         |  0 |        |   0 |         |
-|  new   | bench_repeated_scope_new::scope_1 | 11.41K |         |  0 |        |   0 |         |
+|  new   | bench_repeated_scope_new          | 16.93K |         |  0 |        |   0 |         |
+|  new   | bench_repeated_scope_new::scope_1 |  8.12K |         |  0 |        |   0 |         |
 
 ---------------------------------------------------

--- a/canbench-bin/tests/expected/reports_repeated_scope_in_new_benchmark.txt
+++ b/canbench-bin/tests/expected/reports_repeated_scope_in_new_benchmark.txt
@@ -6,7 +6,7 @@ Benchmark: bench_repeated_scope_new (new)
     heap_increase: 0 pages (new)
     stable_memory_increase: 0 pages (new)
 
-  scope_1 (scope):
+  some_scope1 (scope):
     instructions: 8124 (new)
     heap_increase: 0 pages (new)
     stable_memory_increase: 0 pages (new)
@@ -35,9 +35,9 @@ Summary:
 ---------------------------------------------------
 
 Only significant changes:
-| status | name                              |    ins |  ins Δ% | HI |  HI Δ% | SMI |  SMI Δ% |
-|--------|-----------------------------------|--------|---------|----|--------|-----|---------|
-|  new   | bench_repeated_scope_new          | 14.95K |         |  0 |        |   0 |         |
-|  new   | bench_repeated_scope_new::scope_1 |  8.12K |         |  0 |        |   0 |         |
+| status | name                                  |    ins |  ins Δ% | HI |  HI Δ% | SMI |  SMI Δ% |
+|--------|---------------------------------------|--------|---------|----|--------|-----|---------|
+|  new   | bench_repeated_scope_new              | 14.95K |         |  0 |        |   0 |         |
+|  new   | bench_repeated_scope_new::some_scope1 |  8.12K |         |  0 |        |   0 |         |
 
 ---------------------------------------------------

--- a/canbench-bin/tests/expected/reports_repeated_scope_in_new_benchmark.txt
+++ b/canbench-bin/tests/expected/reports_repeated_scope_in_new_benchmark.txt
@@ -2,12 +2,12 @@
 
 Benchmark: bench_repeated_scope_new (new)
   total:
-    instructions: 16.48 K (new)
+    instructions: 21.60 K (new)
     heap_increase: 0 pages (new)
     stable_memory_increase: 0 pages (new)
 
   scope_1 (scope):
-    instructions: 8124 (new)
+    instructions: 11.41 K (new)
     heap_increase: 0 pages (new)
     stable_memory_increase: 0 pages (new)
 
@@ -37,7 +37,7 @@ Summary:
 Only significant changes:
 | status | name                              |    ins |  ins Δ% | HI |  HI Δ% | SMI |  SMI Δ% |
 |--------|-----------------------------------|--------|---------|----|--------|-----|---------|
-|  new   | bench_repeated_scope_new          | 16.48K |         |  0 |        |   0 |         |
-|  new   | bench_repeated_scope_new::scope_1 |  8.12K |         |  0 |        |   0 |         |
+|  new   | bench_repeated_scope_new          | 21.60K |         |  0 |        |   0 |         |
+|  new   | bench_repeated_scope_new::scope_1 | 11.41K |         |  0 |        |   0 |         |
 
 ---------------------------------------------------

--- a/canbench-bin/tests/expected/reports_scopes_in_existing_benchmark.txt
+++ b/canbench-bin/tests/expected/reports_scopes_in_existing_benchmark.txt
@@ -6,12 +6,12 @@ Benchmark: bench_scope_exists
     heap_increase: 0 pages (no change)
     stable_memory_increase: 0 pages (no change)
 
-  scope_1 (scope):
-    instructions: 1050 (regressed by 31.25%)
-    heap_increase: 0 pages (improved by 100.00%)
-    stable_memory_increase: 0 pages (no change)
+  some_scope1 (scope):
+    instructions: 1050 (new)
+    heap_increase: 0 pages (new)
+    stable_memory_increase: 0 pages (new)
 
-  scope_2 (scope):
+  some_scope2 (scope):
     instructions: 786 (new)
     heap_increase: 0 pages (new)
     stable_memory_increase: 0 pages (new)
@@ -40,10 +40,10 @@ Summary:
 ---------------------------------------------------
 
 Only significant changes:
-| status | name                        |   ins |  ins Δ% | HI |    HI Δ% | SMI |  SMI Δ% |
-|--------|-----------------------------|-------|---------|----|----------|-----|---------|
-|   +    | bench_scope_exists          | 4.10K |   +inf% |  0 |    0.00% |   0 |   0.00% |
-|  +/-   | bench_scope_exists::scope_1 | 1.05K | +31.25% |  0 | -100.00% |   0 |   0.00% |
-|  new   | bench_scope_exists::scope_2 |   786 |         |  0 |          |   0 |         |
+| status | name                            |   ins |  ins Δ% | HI |  HI Δ% | SMI |  SMI Δ% |
+|--------|---------------------------------|-------|---------|----|--------|-----|---------|
+|   +    | bench_scope_exists              | 4.10K |   +inf% |  0 |  0.00% |   0 |   0.00% |
+|  new   | bench_scope_exists::some_scope1 | 1.05K |         |  0 |        |   0 |         |
+|  new   | bench_scope_exists::some_scope2 |   786 |         |  0 |        |   0 |         |
 
 ---------------------------------------------------

--- a/canbench-bin/tests/expected/reports_scopes_in_existing_benchmark.txt
+++ b/canbench-bin/tests/expected/reports_scopes_in_existing_benchmark.txt
@@ -2,17 +2,17 @@
 
 Benchmark: bench_scope_exists
   total:
-    instructions: 4138 (regressed from 0)
+    instructions: 4964 (regressed from 0)
     heap_increase: 0 pages (no change)
     stable_memory_increase: 0 pages (no change)
 
   scope_1 (scope):
-    instructions: 1050 (regressed by 31.25%)
+    instructions: 1401 (regressed by 75.12%)
     heap_increase: 0 pages (improved by 100.00%)
     stable_memory_increase: 0 pages (no change)
 
   scope_2 (scope):
-    instructions: 786 (new)
+    instructions: 1113 (new)
     heap_increase: 0 pages (new)
     stable_memory_increase: 0 pages (new)
 
@@ -22,7 +22,7 @@ Summary:
   instructions:
     status:   Regressions detected! 🔴
     counts:   [total 1 | new 0 | improved 0 | regressed 1 | unchanged 0]
-    change:   [min +4.14K | med +4.14K | max +4.14K]
+    change:   [min +4.96K | med +4.96K | max +4.96K]
     change %: [min +inf% | med +inf% | max +inf%]
 
   heap_increase:
@@ -42,8 +42,8 @@ Summary:
 Only significant changes:
 | status | name                        |   ins |  ins Δ% | HI |    HI Δ% | SMI |  SMI Δ% |
 |--------|-----------------------------|-------|---------|----|----------|-----|---------|
-|   +    | bench_scope_exists          | 4.14K |   +inf% |  0 |    0.00% |   0 |   0.00% |
-|  +/-   | bench_scope_exists::scope_1 | 1.05K | +31.25% |  0 | -100.00% |   0 |   0.00% |
-|  new   | bench_scope_exists::scope_2 |   786 |         |  0 |          |   0 |         |
+|   +    | bench_scope_exists          | 4.96K |   +inf% |  0 |    0.00% |   0 |   0.00% |
+|  +/-   | bench_scope_exists::scope_1 | 1.40K | +75.12% |  0 | -100.00% |   0 |   0.00% |
+|  new   | bench_scope_exists::scope_2 | 1.11K |         |  0 |          |   0 |         |
 
 ---------------------------------------------------

--- a/canbench-bin/tests/expected/reports_scopes_in_existing_benchmark.txt
+++ b/canbench-bin/tests/expected/reports_scopes_in_existing_benchmark.txt
@@ -2,7 +2,7 @@
 
 Benchmark: bench_scope_exists
   total:
-    instructions: 4204 (regressed from 0)
+    instructions: 4096 (regressed from 0)
     heap_increase: 0 pages (no change)
     stable_memory_increase: 0 pages (no change)
 
@@ -22,7 +22,7 @@ Summary:
   instructions:
     status:   Regressions detected! 🔴
     counts:   [total 1 | new 0 | improved 0 | regressed 1 | unchanged 0]
-    change:   [min +4.20K | med +4.20K | max +4.20K]
+    change:   [min +4.10K | med +4.10K | max +4.10K]
     change %: [min +inf% | med +inf% | max +inf%]
 
   heap_increase:
@@ -42,7 +42,7 @@ Summary:
 Only significant changes:
 | status | name                        |   ins |  ins Δ% | HI |    HI Δ% | SMI |  SMI Δ% |
 |--------|-----------------------------|-------|---------|----|----------|-----|---------|
-|   +    | bench_scope_exists          | 4.20K |   +inf% |  0 |    0.00% |   0 |   0.00% |
+|   +    | bench_scope_exists          | 4.10K |   +inf% |  0 |    0.00% |   0 |   0.00% |
 |  +/-   | bench_scope_exists::scope_1 | 1.05K | +31.25% |  0 | -100.00% |   0 |   0.00% |
 |  new   | bench_scope_exists::scope_2 |   786 |         |  0 |          |   0 |         |
 

--- a/canbench-bin/tests/expected/reports_scopes_in_existing_benchmark.txt
+++ b/canbench-bin/tests/expected/reports_scopes_in_existing_benchmark.txt
@@ -2,17 +2,17 @@
 
 Benchmark: bench_scope_exists
   total:
-    instructions: 4964 (regressed from 0)
+    instructions: 4204 (regressed from 0)
     heap_increase: 0 pages (no change)
     stable_memory_increase: 0 pages (no change)
 
   scope_1 (scope):
-    instructions: 1401 (regressed by 75.12%)
+    instructions: 1050 (regressed by 31.25%)
     heap_increase: 0 pages (improved by 100.00%)
     stable_memory_increase: 0 pages (no change)
 
   scope_2 (scope):
-    instructions: 1113 (new)
+    instructions: 786 (new)
     heap_increase: 0 pages (new)
     stable_memory_increase: 0 pages (new)
 
@@ -22,7 +22,7 @@ Summary:
   instructions:
     status:   Regressions detected! 🔴
     counts:   [total 1 | new 0 | improved 0 | regressed 1 | unchanged 0]
-    change:   [min +4.96K | med +4.96K | max +4.96K]
+    change:   [min +4.20K | med +4.20K | max +4.20K]
     change %: [min +inf% | med +inf% | max +inf%]
 
   heap_increase:
@@ -42,8 +42,8 @@ Summary:
 Only significant changes:
 | status | name                        |   ins |  ins Δ% | HI |    HI Δ% | SMI |  SMI Δ% |
 |--------|-----------------------------|-------|---------|----|----------|-----|---------|
-|   +    | bench_scope_exists          | 4.96K |   +inf% |  0 |    0.00% |   0 |   0.00% |
-|  +/-   | bench_scope_exists::scope_1 | 1.40K | +75.12% |  0 | -100.00% |   0 |   0.00% |
-|  new   | bench_scope_exists::scope_2 | 1.11K |         |  0 |          |   0 |         |
+|   +    | bench_scope_exists          | 4.20K |   +inf% |  0 |    0.00% |   0 |   0.00% |
+|  +/-   | bench_scope_exists::scope_1 | 1.05K | +31.25% |  0 | -100.00% |   0 |   0.00% |
+|  new   | bench_scope_exists::scope_2 |   786 |         |  0 |          |   0 |         |
 
 ---------------------------------------------------

--- a/canbench-bin/tests/expected/reports_scopes_in_new_benchmark.txt
+++ b/canbench-bin/tests/expected/reports_scopes_in_new_benchmark.txt
@@ -2,7 +2,7 @@
 
 Benchmark: bench_scope_new (new)
   total:
-    instructions: 4204 (new)
+    instructions: 4096 (new)
     heap_increase: 0 pages (new)
     stable_memory_increase: 0 pages (new)
 
@@ -42,7 +42,7 @@ Summary:
 Only significant changes:
 | status | name                     |   ins |  ins Δ% | HI |  HI Δ% | SMI |  SMI Δ% |
 |--------|--------------------------|-------|---------|----|--------|-----|---------|
-|  new   | bench_scope_new          | 4.20K |         |  0 |        |   0 |         |
+|  new   | bench_scope_new          | 4.10K |         |  0 |        |   0 |         |
 |  new   | bench_scope_new::scope_1 | 1.05K |         |  0 |        |   0 |         |
 |  new   | bench_scope_new::scope_2 |   786 |         |  0 |        |   0 |         |
 

--- a/canbench-bin/tests/expected/reports_scopes_in_new_benchmark.txt
+++ b/canbench-bin/tests/expected/reports_scopes_in_new_benchmark.txt
@@ -6,12 +6,12 @@ Benchmark: bench_scope_new (new)
     heap_increase: 0 pages (new)
     stable_memory_increase: 0 pages (new)
 
-  scope_1 (scope):
+  some_scope1 (scope):
     instructions: 1050 (new)
     heap_increase: 0 pages (new)
     stable_memory_increase: 0 pages (new)
 
-  scope_2 (scope):
+  some_scope2 (scope):
     instructions: 786 (new)
     heap_increase: 0 pages (new)
     stable_memory_increase: 0 pages (new)
@@ -40,10 +40,10 @@ Summary:
 ---------------------------------------------------
 
 Only significant changes:
-| status | name                     |   ins |  ins Δ% | HI |  HI Δ% | SMI |  SMI Δ% |
-|--------|--------------------------|-------|---------|----|--------|-----|---------|
-|  new   | bench_scope_new          | 4.10K |         |  0 |        |   0 |         |
-|  new   | bench_scope_new::scope_1 | 1.05K |         |  0 |        |   0 |         |
-|  new   | bench_scope_new::scope_2 |   786 |         |  0 |        |   0 |         |
+| status | name                         |   ins |  ins Δ% | HI |  HI Δ% | SMI |  SMI Δ% |
+|--------|------------------------------|-------|---------|----|--------|-----|---------|
+|  new   | bench_scope_new              | 4.10K |         |  0 |        |   0 |         |
+|  new   | bench_scope_new::some_scope1 | 1.05K |         |  0 |        |   0 |         |
+|  new   | bench_scope_new::some_scope2 |   786 |         |  0 |        |   0 |         |
 
 ---------------------------------------------------

--- a/canbench-bin/tests/expected/reports_scopes_in_new_benchmark.txt
+++ b/canbench-bin/tests/expected/reports_scopes_in_new_benchmark.txt
@@ -2,17 +2,17 @@
 
 Benchmark: bench_scope_new (new)
   total:
-    instructions: 4964 (new)
+    instructions: 4204 (new)
     heap_increase: 0 pages (new)
     stable_memory_increase: 0 pages (new)
 
   scope_1 (scope):
-    instructions: 1401 (new)
+    instructions: 1050 (new)
     heap_increase: 0 pages (new)
     stable_memory_increase: 0 pages (new)
 
   scope_2 (scope):
-    instructions: 1113 (new)
+    instructions: 786 (new)
     heap_increase: 0 pages (new)
     stable_memory_increase: 0 pages (new)
 
@@ -42,8 +42,8 @@ Summary:
 Only significant changes:
 | status | name                     |   ins |  ins Δ% | HI |  HI Δ% | SMI |  SMI Δ% |
 |--------|--------------------------|-------|---------|----|--------|-----|---------|
-|  new   | bench_scope_new          | 4.96K |         |  0 |        |   0 |         |
-|  new   | bench_scope_new::scope_1 | 1.40K |         |  0 |        |   0 |         |
-|  new   | bench_scope_new::scope_2 | 1.11K |         |  0 |        |   0 |         |
+|  new   | bench_scope_new          | 4.20K |         |  0 |        |   0 |         |
+|  new   | bench_scope_new::scope_1 | 1.05K |         |  0 |        |   0 |         |
+|  new   | bench_scope_new::scope_2 |   786 |         |  0 |        |   0 |         |
 
 ---------------------------------------------------

--- a/canbench-bin/tests/expected/reports_scopes_in_new_benchmark.txt
+++ b/canbench-bin/tests/expected/reports_scopes_in_new_benchmark.txt
@@ -2,17 +2,17 @@
 
 Benchmark: bench_scope_new (new)
   total:
-    instructions: 4138 (new)
+    instructions: 4964 (new)
     heap_increase: 0 pages (new)
     stable_memory_increase: 0 pages (new)
 
   scope_1 (scope):
-    instructions: 1050 (new)
+    instructions: 1401 (new)
     heap_increase: 0 pages (new)
     stable_memory_increase: 0 pages (new)
 
   scope_2 (scope):
-    instructions: 786 (new)
+    instructions: 1113 (new)
     heap_increase: 0 pages (new)
     stable_memory_increase: 0 pages (new)
 
@@ -42,8 +42,8 @@ Summary:
 Only significant changes:
 | status | name                     |   ins |  ins Δ% | HI |  HI Δ% | SMI |  SMI Δ% |
 |--------|--------------------------|-------|---------|----|--------|-----|---------|
-|  new   | bench_scope_new          | 4.14K |         |  0 |        |   0 |         |
-|  new   | bench_scope_new::scope_1 | 1.05K |         |  0 |        |   0 |         |
-|  new   | bench_scope_new::scope_2 |   786 |         |  0 |        |   0 |         |
+|  new   | bench_scope_new          | 4.96K |         |  0 |        |   0 |         |
+|  new   | bench_scope_new::scope_1 | 1.40K |         |  0 |        |   0 |         |
+|  new   | bench_scope_new::scope_2 | 1.11K |         |  0 |        |   0 |         |
 
 ---------------------------------------------------

--- a/canbench-rs-macros/Cargo.toml
+++ b/canbench-rs-macros/Cargo.toml
@@ -15,3 +15,4 @@ proc-macro = true
 proc-macro2.workspace = true
 quote.workspace = true
 syn = { workspace = true, features = ["full"] }
+heck = "0.5.0"

--- a/canbench-rs-macros/src/lib.rs
+++ b/canbench-rs-macros/src/lib.rs
@@ -163,7 +163,12 @@ pub fn bench_id_enum(input: TokenStream) -> TokenStream {
             {
                 lit_int.base10_parse::<u16>().unwrap_or(id_counter)
             } else {
-                id_counter
+                return syn::Error::new_spanned(
+                    expr,
+                    "Only integer literals are supported as discriminant values for `BenchIdEnum` variants.",
+                )
+                .to_compile_error()
+                .into();
             }
         } else {
             id_counter

--- a/canbench-rs/src/lib.rs
+++ b/canbench-rs/src/lib.rs
@@ -598,13 +598,13 @@ pub fn bench_scope(name: &'static str) -> BenchScope {
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum BenchId {
-    Name(String),
+    Name(&'static str),
     Id(u16),
 }
 
 impl BenchId {
     fn new(name: &'static str) -> Self {
-        Self::Name(name.to_string())
+        Self::Name(name)
     }
 
     fn from_id(id: u16) -> Self {

--- a/canbench-rs/src/lib.rs
+++ b/canbench-rs/src/lib.rs
@@ -470,7 +470,7 @@ use serde::{Deserialize, Serialize};
 use std::{cell::RefCell, collections::BTreeMap, ops::Add};
 
 thread_local! {
-    static SCOPES: RefCell<BTreeMap<BenchId, Vec<Measurement>>> =
+    static SCOPES: RefCell<BTreeMap<BenchName, Vec<Measurement>>> =
         const { RefCell::new(BTreeMap::new()) };
 }
 
@@ -597,12 +597,12 @@ pub fn bench_scope(name: &'static str) -> BenchScope {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
-pub enum BenchId {
+pub enum BenchName {
     Name(&'static str),
     Id(u16),
 }
 
-impl BenchId {
+impl BenchName {
     fn new(name: &'static str) -> Self {
         Self::Name(name)
     }
@@ -612,7 +612,7 @@ impl BenchId {
     }
 }
 
-impl std::fmt::Display for BenchId {
+impl std::fmt::Display for BenchName {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Name(name) => write!(f, "{}", name),
@@ -623,7 +623,7 @@ impl std::fmt::Display for BenchId {
 
 /// An object used for benchmarking a specific scope.
 pub struct BenchScope {
-    id: BenchId,
+    id: BenchName,
     start_instructions: u64,
     start_stable_memory: u64,
     start_heap: u64,
@@ -636,7 +636,7 @@ impl BenchScope {
         let start_instructions = instruction_count();
 
         Self {
-            id: BenchId::new(name),
+            id: BenchName::new(name),
             start_instructions,
             start_stable_memory,
             start_heap,
@@ -652,7 +652,7 @@ impl Drop for BenchScope {
 
         SCOPES.with(|p| {
             let mut p = p.borrow_mut();
-            let mut id = BenchId::from_id(0);
+            let mut id = BenchName::from_id(0);
             std::mem::swap(&mut self.id, &mut id);
             p.entry(id).or_default().push(Measurement {
                 instructions,

--- a/canbench-rs/src/lib.rs
+++ b/canbench-rs/src/lib.rs
@@ -699,8 +699,8 @@ impl Drop for BenchScope {
 
         SCOPES.with(|p| {
             let mut p = p.borrow_mut();
-            let mut id = BenchName::from_id(0);
-            std::mem::swap(&mut self.id, &mut id);
+            // Move out `self.id` without cloning, leave a dummy value behind.
+            let id = std::mem::replace(&mut self.id, BenchName::from_id(0));
             p.entry(id).or_default().push(Measurement {
                 instructions,
                 heap_increase,

--- a/canbench-rs/src/lib.rs
+++ b/canbench-rs/src/lib.rs
@@ -592,6 +592,7 @@ pub fn bench_fn<R>(f: impl FnOnce() -> R) -> BenchResult {
 ///   // Do something.
 /// }
 /// ```
+#[must_use]
 pub fn bench_scope(name: &'static str) -> BenchScope {
     BenchScope::new(name)
 }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -31,6 +31,7 @@ path = "stable_memory_invalid/src/main.rs"
 
 [dependencies]
 canbench-rs = { path = "../canbench-rs" }
+canbench-rs-macros = { path = "../canbench-rs-macros" }
 candid.workspace = true
 ic-cdk.workspace = true
 ic-cdk-macros.workspace = true

--- a/tests/measurements_output/src/main.rs
+++ b/tests/measurements_output/src/main.rs
@@ -1,4 +1,5 @@
 use canbench_rs::{bench, bench_fn, bench_scope_id, set_bench_id_resolver, BenchId, BenchResult};
+use canbench_rs_macros::BenchIdEnum;
 
 #[link(wasm_import_module = "ic0")]
 extern "C" {
@@ -71,21 +72,10 @@ fn write_stable_memory() {
     }
 }
 
-#[repr(u16)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, BenchIdEnum)]
 enum Scopes {
-    Scope1 = 0,
-    Scope2 = 1,
-}
-
-impl BenchId for Scopes {
-    fn name_from_id(id: u16) -> Option<&'static str> {
-        match id {
-            0 => Some("scope_1"),
-            1 => Some("scope_2"),
-            _ => None,
-        }
-    }
+    SomeScope1 = 0,
+    SomeScope2 = 1,
 }
 
 // A benchmark that includes some profiling, but isn't persisted in the results.
@@ -94,12 +84,12 @@ fn bench_scope_new() {
     set_bench_id_resolver::<Scopes>();
 
     {
-        let _p = bench_scope_id(Scopes::Scope1 as u16);
+        let _p = bench_scope_id(Scopes::SomeScope1 as u16);
         println!("do something");
     }
 
     {
-        let _p = bench_scope_id(Scopes::Scope2 as u16);
+        let _p = bench_scope_id(Scopes::SomeScope2 as u16);
         println!("do something else");
     }
 }
@@ -110,12 +100,12 @@ fn bench_scope_exists() {
     set_bench_id_resolver::<Scopes>();
 
     {
-        let _p = bench_scope_id(Scopes::Scope1 as u16);
+        let _p = bench_scope_id(Scopes::SomeScope1 as u16);
         println!("do something");
     }
 
     {
-        let _p = bench_scope_id(Scopes::Scope2 as u16);
+        let _p = bench_scope_id(Scopes::SomeScope2 as u16);
         println!("do something else");
     }
 }
@@ -127,7 +117,7 @@ fn bench_repeated_scope_new() {
 
     {
         for _ in 0..10 {
-            let _p = bench_scope_id(Scopes::Scope1 as u16);
+            let _p = bench_scope_id(Scopes::SomeScope1 as u16);
             println!("do something");
         }
     }
@@ -140,7 +130,7 @@ fn bench_repeated_scope_exists() {
 
     {
         for _ in 0..10 {
-            let _p = bench_scope_id(Scopes::Scope1 as u16);
+            let _p = bench_scope_id(Scopes::SomeScope1 as u16);
             println!("do something");
         }
     }

--- a/tests/measurements_output/src/main.rs
+++ b/tests/measurements_output/src/main.rs
@@ -1,4 +1,4 @@
-use canbench_rs::{bench, bench_fn, bench_scope, BenchResult};
+use canbench_rs::{bench, bench_fn, bench_scope_id, set_bench_id_resolver, BenchId, BenchResult};
 
 #[link(wasm_import_module = "ic0")]
 extern "C" {
@@ -71,16 +71,35 @@ fn write_stable_memory() {
     }
 }
 
+#[repr(u16)]
+#[derive(Copy, Clone)]
+enum Scopes {
+    Scope1 = 0,
+    Scope2 = 1,
+}
+
+impl BenchId for Scopes {
+    fn name_from_id(id: u16) -> Option<&'static str> {
+        match id {
+            0 => Some("scope_1"),
+            1 => Some("scope_2"),
+            _ => None,
+        }
+    }
+}
+
 // A benchmark that includes some profiling, but isn't persisted in the results.
 #[bench]
 fn bench_scope_new() {
+    set_bench_id_resolver::<Scopes>();
+
     {
-        let _p = bench_scope("scope_1");
+        let _p = bench_scope_id(Scopes::Scope1 as u16);
         println!("do something");
     }
 
     {
-        let _p = bench_scope("scope_2");
+        let _p = bench_scope_id(Scopes::Scope2 as u16);
         println!("do something else");
     }
 }
@@ -88,13 +107,15 @@ fn bench_scope_new() {
 // A benchmark that includes some profiling and is persisted in the results.
 #[bench]
 fn bench_scope_exists() {
+    set_bench_id_resolver::<Scopes>();
+
     {
-        let _p = bench_scope("scope_1");
+        let _p = bench_scope_id(Scopes::Scope1 as u16);
         println!("do something");
     }
 
     {
-        let _p = bench_scope("scope_2");
+        let _p = bench_scope_id(Scopes::Scope2 as u16);
         println!("do something else");
     }
 }
@@ -102,9 +123,11 @@ fn bench_scope_exists() {
 // A benchmark that includes a repeated scope, but isn't persisted in the results.
 #[bench]
 fn bench_repeated_scope_new() {
+    set_bench_id_resolver::<Scopes>();
+
     {
         for _ in 0..10 {
-            let _p = bench_scope("scope_1");
+            let _p = bench_scope_id(Scopes::Scope1 as u16);
             println!("do something");
         }
     }
@@ -113,9 +136,11 @@ fn bench_repeated_scope_new() {
 // A benchmark that includes a repeated scope and is persisted in the results.
 #[bench]
 fn bench_repeated_scope_exists() {
+    set_bench_id_resolver::<Scopes>();
+
     {
         for _ in 0..10 {
-            let _p = bench_scope("scope_1");
+            let _p = bench_scope_id(Scopes::Scope1 as u16);
             println!("do something");
         }
     }

--- a/tests/measurements_output/src/main.rs
+++ b/tests/measurements_output/src/main.rs
@@ -74,8 +74,8 @@ fn write_stable_memory() {
 
 #[derive(Copy, Clone, BenchIdEnum)]
 enum Scopes {
-    SomeScope1 = 0,
-    SomeScope2 = 1,
+    SomeScope1,
+    SomeScope2,
 }
 
 // A benchmark that includes some profiling, but isn't persisted in the results.

--- a/tests/measurements_output/src/main.rs
+++ b/tests/measurements_output/src/main.rs
@@ -78,10 +78,14 @@ enum Scopes {
     SomeScope2,
 }
 
+fn setup_bench_id_resolver() {
+    set_bench_id_resolver::<Scopes>();
+}
+
 // A benchmark that includes some profiling, but isn't persisted in the results.
 #[bench]
 fn bench_scope_new() {
-    set_bench_id_resolver::<Scopes>();
+    setup_bench_id_resolver();
 
     {
         let _p = bench_scope_id(Scopes::SomeScope1 as u16);
@@ -97,7 +101,7 @@ fn bench_scope_new() {
 // A benchmark that includes some profiling and is persisted in the results.
 #[bench]
 fn bench_scope_exists() {
-    set_bench_id_resolver::<Scopes>();
+    setup_bench_id_resolver();
 
     {
         let _p = bench_scope_id(Scopes::SomeScope1 as u16);
@@ -113,7 +117,7 @@ fn bench_scope_exists() {
 // A benchmark that includes a repeated scope, but isn't persisted in the results.
 #[bench]
 fn bench_repeated_scope_new() {
-    set_bench_id_resolver::<Scopes>();
+    setup_bench_id_resolver();
 
     {
         for _ in 0..10 {
@@ -126,7 +130,7 @@ fn bench_repeated_scope_new() {
 // A benchmark that includes a repeated scope and is persisted in the results.
 #[bench]
 fn bench_repeated_scope_exists() {
-    set_bench_id_resolver::<Scopes>();
+    setup_bench_id_resolver();
 
     {
         for _ in 0..10 {


### PR DESCRIPTION
This PR improves performance measurements by adding numeric-based benchmark scopes.

- Introduced `bench_scope_id` and `BenchId` traits to support numeric IDs
- Added a `BenchIdEnum` derive macro to enable enum-based scope definitions with `snake_case` conversion
- Updated benchmark tests and expected reports to reflect the new scope naming convention

On provided simple examples it improves performance -1...-9%

<img width="350" alt="image" src="https://github.com/user-attachments/assets/8d41592e-9689-449d-9d0b-5cfb2d9e9502" />
