### PR TITLE
feat: switch summary stats to five-number format

### DIFF
--- a/canbench-bin/src/summary.rs
+++ b/canbench-bin/src/summary.rs
@@ -90,20 +90,21 @@ where
 {
     let mut sorted = values.to_vec();
     sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
-    let max = sorted.last().copied().unwrap();
-    let p75 = percentile_fn(&sorted, 75);
-    let p50 = percentile_fn(&sorted, 50);
-    let p25 = percentile_fn(&sorted, 25);
-    let min = sorted.first().copied().unwrap();
 
-    println!(
-        "{prefix} [max {} | p75 {} | median {} | p25 {} | min {}]",
-        format(max),
-        format(p75),
-        format(p50),
-        format(p25),
-        format(min),
-    );
+    let out = [
+        ("max", sorted.last().copied().unwrap()),
+        ("p75", percentile_fn(&sorted, 75)),
+        ("median", percentile_fn(&sorted, 50)),
+        ("p25", percentile_fn(&sorted, 25)),
+        ("min", sorted.first().copied().unwrap()),
+    ];
+
+    let parts: Vec<String> = out
+        .iter()
+        .map(|(label, v)| format!("{label} {}", format(*v)))
+        .collect();
+
+    println!("{prefix} [{}]", parts.join(" | "));
 }
 
 fn percentile_f64(sorted: &[f64], pct: usize) -> f64 {

--- a/canbench-bin/src/summary.rs
+++ b/canbench-bin/src/summary.rs
@@ -97,7 +97,7 @@ where
     let min = sorted.first().copied().unwrap();
 
     println!(
-        "{prefix} [max {} | p75 {} | p50 {} | p25 {} | min {}]",
+        "{prefix} [max {} | p75 {} | median {} | p25 {} | min {}]",
         format(max),
         format(p75),
         format(p50),

--- a/canbench-bin/src/summary.rs
+++ b/canbench-bin/src/summary.rs
@@ -54,9 +54,9 @@ where
     println!("  {label}:");
     let status = match (improved, regressed) {
         (0, 0) => "No significant changes detected 👍",
-        (_, 0) => "Improvements detected! 🟢",
         (0, _) => "Regressions detected! 🔴",
-        _ => "Both improvements and regressions detected! 🟢🔴",
+        (_, 0) => "Improvements detected! 🟢",
+        _ => "Both regressions and improvements detected! 🔴🟢",
     };
     println!("    status:   {status}");
     println!(
@@ -90,15 +90,19 @@ where
 {
     let mut sorted = values.to_vec();
     sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
-    let min = sorted.first().copied().unwrap();
-    let med = percentile_fn(&sorted, 50);
     let max = sorted.last().copied().unwrap();
+    let p75 = percentile_fn(&sorted, 75);
+    let p50 = percentile_fn(&sorted, 50);
+    let p25 = percentile_fn(&sorted, 25);
+    let min = sorted.first().copied().unwrap();
 
     println!(
-        "{prefix} [min {} | med {} | max {}]",
-        format(min),
-        format(med),
+        "{prefix} [max {} | p75 {} | p50 {} | p25 {} | min {}]",
         format(max),
+        format(p75),
+        format(p50),
+        format(p25),
+        format(min),
     );
 }
 

--- a/canbench-bin/tests/expected/benchmark_reports_improvement.txt
+++ b/canbench-bin/tests/expected/benchmark_reports_improvement.txt
@@ -12,20 +12,20 @@ Summary:
   instructions:
     status:   Improvements detected! 🟢
     counts:   [total 1 | new 0 | improved 1 | regressed 0 | unchanged 0]
-    change:   [max -2.89K | p75 -2.89K | p50 -2.89K | p25 -2.89K | min -2.89K]
-    change %: [max -93.32% | p75 -93.32% | p50 -93.32% | p25 -93.32% | min -93.32%]
+    change:   [max -2.89K | p75 -2.89K | median -2.89K | p25 -2.89K | min -2.89K]
+    change %: [max -93.32% | p75 -93.32% | median -93.32% | p25 -93.32% | min -93.32%]
 
   heap_increase:
     status:   No significant changes detected 👍
     counts:   [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
-    change:   [max 0 | p75 0 | p50 0 | p25 0 | min 0]
-    change %: [max 0.00% | p75 0.00% | p50 0.00% | p25 0.00% | min 0.00%]
+    change:   [max 0 | p75 0 | median 0 | p25 0 | min 0]
+    change %: [max 0.00% | p75 0.00% | median 0.00% | p25 0.00% | min 0.00%]
 
   stable_memory_increase:
     status:   No significant changes detected 👍
     counts:   [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
-    change:   [max 0 | p75 0 | p50 0 | p25 0 | min 0]
-    change %: [max 0.00% | p75 0.00% | p50 0.00% | p25 0.00% | min 0.00%]
+    change:   [max 0 | p75 0 | median 0 | p25 0 | min 0]
+    change %: [max 0.00% | p75 0.00% | median 0.00% | p25 0.00% | min 0.00%]
 
 ---------------------------------------------------
 

--- a/canbench-bin/tests/expected/benchmark_reports_improvement.txt
+++ b/canbench-bin/tests/expected/benchmark_reports_improvement.txt
@@ -12,20 +12,20 @@ Summary:
   instructions:
     status:   Improvements detected! 🟢
     counts:   [total 1 | new 0 | improved 1 | regressed 0 | unchanged 0]
-    change:   [min -2.89K | med -2.89K | max -2.89K]
-    change %: [min -93.32% | med -93.32% | max -93.32%]
+    change:   [max -2.89K | p75 -2.89K | p50 -2.89K | p25 -2.89K | min -2.89K]
+    change %: [max -93.32% | p75 -93.32% | p50 -93.32% | p25 -93.32% | min -93.32%]
 
   heap_increase:
     status:   No significant changes detected 👍
     counts:   [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
-    change:   [min 0 | med 0 | max 0]
-    change %: [min 0.00% | med 0.00% | max 0.00%]
+    change:   [max 0 | p75 0 | p50 0 | p25 0 | min 0]
+    change %: [max 0.00% | p75 0.00% | p50 0.00% | p25 0.00% | min 0.00%]
 
   stable_memory_increase:
     status:   No significant changes detected 👍
     counts:   [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
-    change:   [min 0 | med 0 | max 0]
-    change %: [min 0.00% | med 0.00% | max 0.00%]
+    change:   [max 0 | p75 0 | p50 0 | p25 0 | min 0]
+    change %: [max 0.00% | p75 0.00% | p50 0.00% | p25 0.00% | min 0.00%]
 
 ---------------------------------------------------
 

--- a/canbench-bin/tests/expected/benchmark_reports_no_changes.txt
+++ b/canbench-bin/tests/expected/benchmark_reports_no_changes.txt
@@ -12,19 +12,19 @@ Summary:
   instructions:
     status:   No significant changes detected 👍
     counts:   [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
-    change:   [max 0 | p75 0 | p50 0 | p25 0 | min 0]
-    change %: [max 0.00% | p75 0.00% | p50 0.00% | p25 0.00% | min 0.00%]
+    change:   [max 0 | p75 0 | median 0 | p25 0 | min 0]
+    change %: [max 0.00% | p75 0.00% | median 0.00% | p25 0.00% | min 0.00%]
 
   heap_increase:
     status:   No significant changes detected 👍
     counts:   [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
-    change:   [max 0 | p75 0 | p50 0 | p25 0 | min 0]
-    change %: [max 0.00% | p75 0.00% | p50 0.00% | p25 0.00% | min 0.00%]
+    change:   [max 0 | p75 0 | median 0 | p25 0 | min 0]
+    change %: [max 0.00% | p75 0.00% | median 0.00% | p25 0.00% | min 0.00%]
 
   stable_memory_increase:
     status:   No significant changes detected 👍
     counts:   [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
-    change:   [max 0 | p75 0 | p50 0 | p25 0 | min 0]
-    change %: [max 0.00% | p75 0.00% | p50 0.00% | p25 0.00% | min 0.00%]
+    change:   [max 0 | p75 0 | median 0 | p25 0 | min 0]
+    change %: [max 0.00% | p75 0.00% | median 0.00% | p25 0.00% | min 0.00%]
 
 ---------------------------------------------------

--- a/canbench-bin/tests/expected/benchmark_reports_no_changes.txt
+++ b/canbench-bin/tests/expected/benchmark_reports_no_changes.txt
@@ -12,19 +12,19 @@ Summary:
   instructions:
     status:   No significant changes detected 👍
     counts:   [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
-    change:   [min 0 | med 0 | max 0]
-    change %: [min 0.00% | med 0.00% | max 0.00%]
+    change:   [max 0 | p75 0 | p50 0 | p25 0 | min 0]
+    change %: [max 0.00% | p75 0.00% | p50 0.00% | p25 0.00% | min 0.00%]
 
   heap_increase:
     status:   No significant changes detected 👍
     counts:   [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
-    change:   [min 0 | med 0 | max 0]
-    change %: [min 0.00% | med 0.00% | max 0.00%]
+    change:   [max 0 | p75 0 | p50 0 | p25 0 | min 0]
+    change %: [max 0.00% | p75 0.00% | p50 0.00% | p25 0.00% | min 0.00%]
 
   stable_memory_increase:
     status:   No significant changes detected 👍
     counts:   [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
-    change:   [min 0 | med 0 | max 0]
-    change %: [min 0.00% | med 0.00% | max 0.00%]
+    change:   [max 0 | p75 0 | p50 0 | p25 0 | min 0]
+    change %: [max 0.00% | p75 0.00% | p50 0.00% | p25 0.00% | min 0.00%]
 
 ---------------------------------------------------

--- a/canbench-bin/tests/expected/benchmark_reports_no_changes_with_hide_results.txt
+++ b/canbench-bin/tests/expected/benchmark_reports_no_changes_with_hide_results.txt
@@ -4,19 +4,19 @@ Summary:
   instructions:
     status:   No significant changes detected 👍
     counts:   [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
-    change:   [max 0 | p75 0 | p50 0 | p25 0 | min 0]
-    change %: [max 0.00% | p75 0.00% | p50 0.00% | p25 0.00% | min 0.00%]
+    change:   [max 0 | p75 0 | median 0 | p25 0 | min 0]
+    change %: [max 0.00% | p75 0.00% | median 0.00% | p25 0.00% | min 0.00%]
 
   heap_increase:
     status:   No significant changes detected 👍
     counts:   [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
-    change:   [max 0 | p75 0 | p50 0 | p25 0 | min 0]
-    change %: [max 0.00% | p75 0.00% | p50 0.00% | p25 0.00% | min 0.00%]
+    change:   [max 0 | p75 0 | median 0 | p25 0 | min 0]
+    change %: [max 0.00% | p75 0.00% | median 0.00% | p25 0.00% | min 0.00%]
 
   stable_memory_increase:
     status:   No significant changes detected 👍
     counts:   [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
-    change:   [max 0 | p75 0 | p50 0 | p25 0 | min 0]
-    change %: [max 0.00% | p75 0.00% | p50 0.00% | p25 0.00% | min 0.00%]
+    change:   [max 0 | p75 0 | median 0 | p25 0 | min 0]
+    change %: [max 0.00% | p75 0.00% | median 0.00% | p25 0.00% | min 0.00%]
 
 ---------------------------------------------------

--- a/canbench-bin/tests/expected/benchmark_reports_no_changes_with_hide_results.txt
+++ b/canbench-bin/tests/expected/benchmark_reports_no_changes_with_hide_results.txt
@@ -4,19 +4,19 @@ Summary:
   instructions:
     status:   No significant changes detected 👍
     counts:   [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
-    change:   [min 0 | med 0 | max 0]
-    change %: [min 0.00% | med 0.00% | max 0.00%]
+    change:   [max 0 | p75 0 | p50 0 | p25 0 | min 0]
+    change %: [max 0.00% | p75 0.00% | p50 0.00% | p25 0.00% | min 0.00%]
 
   heap_increase:
     status:   No significant changes detected 👍
     counts:   [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
-    change:   [min 0 | med 0 | max 0]
-    change %: [min 0.00% | med 0.00% | max 0.00%]
+    change:   [max 0 | p75 0 | p50 0 | p25 0 | min 0]
+    change %: [max 0.00% | p75 0.00% | p50 0.00% | p25 0.00% | min 0.00%]
 
   stable_memory_increase:
     status:   No significant changes detected 👍
     counts:   [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
-    change:   [min 0 | med 0 | max 0]
-    change %: [min 0.00% | med 0.00% | max 0.00%]
+    change:   [max 0 | p75 0 | p50 0 | p25 0 | min 0]
+    change %: [max 0.00% | p75 0.00% | p50 0.00% | p25 0.00% | min 0.00%]
 
 ---------------------------------------------------

--- a/canbench-bin/tests/expected/benchmark_reports_noisy_change.txt
+++ b/canbench-bin/tests/expected/benchmark_reports_noisy_change.txt
@@ -12,19 +12,19 @@ Summary:
   instructions:
     status:   No significant changes detected 👍
     counts:   [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
-    change:   [max -3 | p75 -3 | p50 -3 | p25 -3 | min -3]
-    change %: [max -1.43% | p75 -1.43% | p50 -1.43% | p25 -1.43% | min -1.43%]
+    change:   [max -3 | p75 -3 | median -3 | p25 -3 | min -3]
+    change %: [max -1.43% | p75 -1.43% | median -1.43% | p25 -1.43% | min -1.43%]
 
   heap_increase:
     status:   No significant changes detected 👍
     counts:   [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
-    change:   [max 0 | p75 0 | p50 0 | p25 0 | min 0]
-    change %: [max 0.00% | p75 0.00% | p50 0.00% | p25 0.00% | min 0.00%]
+    change:   [max 0 | p75 0 | median 0 | p25 0 | min 0]
+    change %: [max 0.00% | p75 0.00% | median 0.00% | p25 0.00% | min 0.00%]
 
   stable_memory_increase:
     status:   No significant changes detected 👍
     counts:   [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
-    change:   [max 0 | p75 0 | p50 0 | p25 0 | min 0]
-    change %: [max 0.00% | p75 0.00% | p50 0.00% | p25 0.00% | min 0.00%]
+    change:   [max 0 | p75 0 | median 0 | p25 0 | min 0]
+    change %: [max 0.00% | p75 0.00% | median 0.00% | p25 0.00% | min 0.00%]
 
 ---------------------------------------------------

--- a/canbench-bin/tests/expected/benchmark_reports_noisy_change.txt
+++ b/canbench-bin/tests/expected/benchmark_reports_noisy_change.txt
@@ -12,19 +12,19 @@ Summary:
   instructions:
     status:   No significant changes detected 👍
     counts:   [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
-    change:   [min -3 | med -3 | max -3]
-    change %: [min -1.43% | med -1.43% | max -1.43%]
+    change:   [max -3 | p75 -3 | p50 -3 | p25 -3 | min -3]
+    change %: [max -1.43% | p75 -1.43% | p50 -1.43% | p25 -1.43% | min -1.43%]
 
   heap_increase:
     status:   No significant changes detected 👍
     counts:   [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
-    change:   [min 0 | med 0 | max 0]
-    change %: [min 0.00% | med 0.00% | max 0.00%]
+    change:   [max 0 | p75 0 | p50 0 | p25 0 | min 0]
+    change %: [max 0.00% | p75 0.00% | p50 0.00% | p25 0.00% | min 0.00%]
 
   stable_memory_increase:
     status:   No significant changes detected 👍
     counts:   [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
-    change:   [min 0 | med 0 | max 0]
-    change %: [min 0.00% | med 0.00% | max 0.00%]
+    change:   [max 0 | p75 0 | p50 0 | p25 0 | min 0]
+    change %: [max 0.00% | p75 0.00% | p50 0.00% | p25 0.00% | min 0.00%]
 
 ---------------------------------------------------

--- a/canbench-bin/tests/expected/benchmark_reports_noisy_change_above_default_noise_threshold.txt
+++ b/canbench-bin/tests/expected/benchmark_reports_noisy_change_above_default_noise_threshold.txt
@@ -12,20 +12,20 @@ Summary:
   instructions:
     status:   Improvements detected! 🟢
     counts:   [total 1 | new 0 | improved 1 | regressed 0 | unchanged 0]
-    change:   [min -154.17K | med -154.17K | max -154.17K]
-    change %: [min -4.36% | med -4.36% | max -4.36%]
+    change:   [max -154.17K | p75 -154.17K | p50 -154.17K | p25 -154.17K | min -154.17K]
+    change %: [max -4.36% | p75 -4.36% | p50 -4.36% | p25 -4.36% | min -4.36%]
 
   heap_increase:
     status:   Improvements detected! 🟢
     counts:   [total 1 | new 0 | improved 1 | regressed 0 | unchanged 0]
-    change:   [min -3 | med -3 | max -3]
-    change %: [min -4.62% | med -4.62% | max -4.62%]
+    change:   [max -3 | p75 -3 | p50 -3 | p25 -3 | min -3]
+    change %: [max -4.62% | p75 -4.62% | p50 -4.62% | p25 -4.62% | min -4.62%]
 
   stable_memory_increase:
     status:   Improvements detected! 🟢
     counts:   [total 1 | new 0 | improved 1 | regressed 0 | unchanged 0]
-    change:   [min -4 | med -4 | max -4]
-    change %: [min -3.85% | med -3.85% | max -3.85%]
+    change:   [max -4 | p75 -4 | p50 -4 | p25 -4 | min -4]
+    change %: [max -3.85% | p75 -3.85% | p50 -3.85% | p25 -3.85% | min -3.85%]
 
 ---------------------------------------------------
 

--- a/canbench-bin/tests/expected/benchmark_reports_noisy_change_above_default_noise_threshold.txt
+++ b/canbench-bin/tests/expected/benchmark_reports_noisy_change_above_default_noise_threshold.txt
@@ -12,20 +12,20 @@ Summary:
   instructions:
     status:   Improvements detected! 🟢
     counts:   [total 1 | new 0 | improved 1 | regressed 0 | unchanged 0]
-    change:   [max -154.17K | p75 -154.17K | p50 -154.17K | p25 -154.17K | min -154.17K]
-    change %: [max -4.36% | p75 -4.36% | p50 -4.36% | p25 -4.36% | min -4.36%]
+    change:   [max -154.17K | p75 -154.17K | median -154.17K | p25 -154.17K | min -154.17K]
+    change %: [max -4.36% | p75 -4.36% | median -4.36% | p25 -4.36% | min -4.36%]
 
   heap_increase:
     status:   Improvements detected! 🟢
     counts:   [total 1 | new 0 | improved 1 | regressed 0 | unchanged 0]
-    change:   [max -3 | p75 -3 | p50 -3 | p25 -3 | min -3]
-    change %: [max -4.62% | p75 -4.62% | p50 -4.62% | p25 -4.62% | min -4.62%]
+    change:   [max -3 | p75 -3 | median -3 | p25 -3 | min -3]
+    change %: [max -4.62% | p75 -4.62% | median -4.62% | p25 -4.62% | min -4.62%]
 
   stable_memory_increase:
     status:   Improvements detected! 🟢
     counts:   [total 1 | new 0 | improved 1 | regressed 0 | unchanged 0]
-    change:   [max -4 | p75 -4 | p50 -4 | p25 -4 | min -4]
-    change %: [max -3.85% | p75 -3.85% | p50 -3.85% | p25 -3.85% | min -3.85%]
+    change:   [max -4 | p75 -4 | median -4 | p25 -4 | min -4]
+    change %: [max -3.85% | p75 -3.85% | median -3.85% | p25 -3.85% | min -3.85%]
 
 ---------------------------------------------------
 

--- a/canbench-bin/tests/expected/benchmark_reports_noisy_change_within_custom_noise_threshold.txt
+++ b/canbench-bin/tests/expected/benchmark_reports_noisy_change_within_custom_noise_threshold.txt
@@ -12,19 +12,19 @@ Summary:
   instructions:
     status:   No significant changes detected 👍
     counts:   [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
-    change:   [min -154.17K | med -154.17K | max -154.17K]
-    change %: [min -4.36% | med -4.36% | max -4.36%]
+    change:   [max -154.17K | p75 -154.17K | p50 -154.17K | p25 -154.17K | min -154.17K]
+    change %: [max -4.36% | p75 -4.36% | p50 -4.36% | p25 -4.36% | min -4.36%]
 
   heap_increase:
     status:   No significant changes detected 👍
     counts:   [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
-    change:   [min -3 | med -3 | max -3]
-    change %: [min -4.62% | med -4.62% | max -4.62%]
+    change:   [max -3 | p75 -3 | p50 -3 | p25 -3 | min -3]
+    change %: [max -4.62% | p75 -4.62% | p50 -4.62% | p25 -4.62% | min -4.62%]
 
   stable_memory_increase:
     status:   No significant changes detected 👍
     counts:   [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
-    change:   [min -4 | med -4 | max -4]
-    change %: [min -3.85% | med -3.85% | max -3.85%]
+    change:   [max -4 | p75 -4 | p50 -4 | p25 -4 | min -4]
+    change %: [max -3.85% | p75 -3.85% | p50 -3.85% | p25 -3.85% | min -3.85%]
 
 ---------------------------------------------------

--- a/canbench-bin/tests/expected/benchmark_reports_noisy_change_within_custom_noise_threshold.txt
+++ b/canbench-bin/tests/expected/benchmark_reports_noisy_change_within_custom_noise_threshold.txt
@@ -12,19 +12,19 @@ Summary:
   instructions:
     status:   No significant changes detected 👍
     counts:   [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
-    change:   [max -154.17K | p75 -154.17K | p50 -154.17K | p25 -154.17K | min -154.17K]
-    change %: [max -4.36% | p75 -4.36% | p50 -4.36% | p25 -4.36% | min -4.36%]
+    change:   [max -154.17K | p75 -154.17K | median -154.17K | p25 -154.17K | min -154.17K]
+    change %: [max -4.36% | p75 -4.36% | median -4.36% | p25 -4.36% | min -4.36%]
 
   heap_increase:
     status:   No significant changes detected 👍
     counts:   [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
-    change:   [max -3 | p75 -3 | p50 -3 | p25 -3 | min -3]
-    change %: [max -4.62% | p75 -4.62% | p50 -4.62% | p25 -4.62% | min -4.62%]
+    change:   [max -3 | p75 -3 | median -3 | p25 -3 | min -3]
+    change %: [max -4.62% | p75 -4.62% | median -4.62% | p25 -4.62% | min -4.62%]
 
   stable_memory_increase:
     status:   No significant changes detected 👍
     counts:   [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
-    change:   [max -4 | p75 -4 | p50 -4 | p25 -4 | min -4]
-    change %: [max -3.85% | p75 -3.85% | p50 -3.85% | p25 -3.85% | min -3.85%]
+    change:   [max -4 | p75 -4 | median -4 | p25 -4 | min -4]
+    change %: [max -3.85% | p75 -3.85% | median -3.85% | p25 -3.85% | min -3.85%]
 
 ---------------------------------------------------

--- a/canbench-bin/tests/expected/benchmark_reports_regression.txt
+++ b/canbench-bin/tests/expected/benchmark_reports_regression.txt
@@ -12,20 +12,20 @@ Summary:
   instructions:
     status:   Regressions detected! 🔴
     counts:   [total 1 | new 0 | improved 0 | regressed 1 | unchanged 0]
-    change:   [max +197 | p75 +197 | p50 +197 | p25 +197 | min +197]
-    change %: [max +1970.00% | p75 +1970.00% | p50 +1970.00% | p25 +1970.00% | min +1970.00%]
+    change:   [max +197 | p75 +197 | median +197 | p25 +197 | min +197]
+    change %: [max +1970.00% | p75 +1970.00% | median +1970.00% | p25 +1970.00% | min +1970.00%]
 
   heap_increase:
     status:   No significant changes detected 👍
     counts:   [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
-    change:   [max 0 | p75 0 | p50 0 | p25 0 | min 0]
-    change %: [max 0.00% | p75 0.00% | p50 0.00% | p25 0.00% | min 0.00%]
+    change:   [max 0 | p75 0 | median 0 | p25 0 | min 0]
+    change %: [max 0.00% | p75 0.00% | median 0.00% | p25 0.00% | min 0.00%]
 
   stable_memory_increase:
     status:   No significant changes detected 👍
     counts:   [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
-    change:   [max 0 | p75 0 | p50 0 | p25 0 | min 0]
-    change %: [max 0.00% | p75 0.00% | p50 0.00% | p25 0.00% | min 0.00%]
+    change:   [max 0 | p75 0 | median 0 | p25 0 | min 0]
+    change %: [max 0.00% | p75 0.00% | median 0.00% | p25 0.00% | min 0.00%]
 
 ---------------------------------------------------
 

--- a/canbench-bin/tests/expected/benchmark_reports_regression.txt
+++ b/canbench-bin/tests/expected/benchmark_reports_regression.txt
@@ -12,20 +12,20 @@ Summary:
   instructions:
     status:   Regressions detected! 🔴
     counts:   [total 1 | new 0 | improved 0 | regressed 1 | unchanged 0]
-    change:   [min +197 | med +197 | max +197]
-    change %: [min +1970.00% | med +1970.00% | max +1970.00%]
+    change:   [max +197 | p75 +197 | p50 +197 | p25 +197 | min +197]
+    change %: [max +1970.00% | p75 +1970.00% | p50 +1970.00% | p25 +1970.00% | min +1970.00%]
 
   heap_increase:
     status:   No significant changes detected 👍
     counts:   [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
-    change:   [min 0 | med 0 | max 0]
-    change %: [min 0.00% | med 0.00% | max 0.00%]
+    change:   [max 0 | p75 0 | p50 0 | p25 0 | min 0]
+    change %: [max 0.00% | p75 0.00% | p50 0.00% | p25 0.00% | min 0.00%]
 
   stable_memory_increase:
     status:   No significant changes detected 👍
     counts:   [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
-    change:   [min 0 | med 0 | max 0]
-    change %: [min 0.00% | med 0.00% | max 0.00%]
+    change:   [max 0 | p75 0 | p50 0 | p25 0 | min 0]
+    change %: [max 0.00% | p75 0.00% | p50 0.00% | p25 0.00% | min 0.00%]
 
 ---------------------------------------------------
 

--- a/canbench-bin/tests/expected/benchmark_reports_regression_from_zero.txt
+++ b/canbench-bin/tests/expected/benchmark_reports_regression_from_zero.txt
@@ -12,20 +12,20 @@ Summary:
   instructions:
     status:   Regressions detected! 🔴
     counts:   [total 1 | new 0 | improved 0 | regressed 1 | unchanged 0]
-    change:   [max +307 | p75 +307 | p50 +307 | p25 +307 | min +307]
-    change %: [max +inf% | p75 +inf% | p50 +inf% | p25 +inf% | min +inf%]
+    change:   [max +307 | p75 +307 | median +307 | p25 +307 | min +307]
+    change %: [max +inf% | p75 +inf% | median +inf% | p25 +inf% | min +inf%]
 
   heap_increase:
     status:   No significant changes detected 👍
     counts:   [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
-    change:   [max 0 | p75 0 | p50 0 | p25 0 | min 0]
-    change %: [max 0.00% | p75 0.00% | p50 0.00% | p25 0.00% | min 0.00%]
+    change:   [max 0 | p75 0 | median 0 | p25 0 | min 0]
+    change %: [max 0.00% | p75 0.00% | median 0.00% | p25 0.00% | min 0.00%]
 
   stable_memory_increase:
     status:   Regressions detected! 🔴
     counts:   [total 1 | new 0 | improved 0 | regressed 1 | unchanged 0]
-    change:   [max +123 | p75 +123 | p50 +123 | p25 +123 | min +123]
-    change %: [max +inf% | p75 +inf% | p50 +inf% | p25 +inf% | min +inf%]
+    change:   [max +123 | p75 +123 | median +123 | p25 +123 | min +123]
+    change %: [max +inf% | p75 +inf% | median +inf% | p25 +inf% | min +inf%]
 
 ---------------------------------------------------
 

--- a/canbench-bin/tests/expected/benchmark_reports_regression_from_zero.txt
+++ b/canbench-bin/tests/expected/benchmark_reports_regression_from_zero.txt
@@ -12,20 +12,20 @@ Summary:
   instructions:
     status:   Regressions detected! 🔴
     counts:   [total 1 | new 0 | improved 0 | regressed 1 | unchanged 0]
-    change:   [min +307 | med +307 | max +307]
-    change %: [min +inf% | med +inf% | max +inf%]
+    change:   [max +307 | p75 +307 | p50 +307 | p25 +307 | min +307]
+    change %: [max +inf% | p75 +inf% | p50 +inf% | p25 +inf% | min +inf%]
 
   heap_increase:
     status:   No significant changes detected 👍
     counts:   [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
-    change:   [min 0 | med 0 | max 0]
-    change %: [min 0.00% | med 0.00% | max 0.00%]
+    change:   [max 0 | p75 0 | p50 0 | p25 0 | min 0]
+    change %: [max 0.00% | p75 0.00% | p50 0.00% | p25 0.00% | min 0.00%]
 
   stable_memory_increase:
     status:   Regressions detected! 🔴
     counts:   [total 1 | new 0 | improved 0 | regressed 1 | unchanged 0]
-    change:   [min +123 | med +123 | max +123]
-    change %: [min +inf% | med +inf% | max +inf%]
+    change:   [max +123 | p75 +123 | p50 +123 | p25 +123 | min +123]
+    change %: [max +inf% | p75 +inf% | p50 +inf% | p25 +inf% | min +inf%]
 
 ---------------------------------------------------
 

--- a/canbench-bin/tests/expected/benchmark_works_with_init_args.txt
+++ b/canbench-bin/tests/expected/benchmark_works_with_init_args.txt
@@ -12,19 +12,19 @@ Summary:
   instructions:
     status:   No significant changes detected 👍
     counts:   [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
-    change:   [max 0 | p75 0 | p50 0 | p25 0 | min 0]
-    change %: [max 0.00% | p75 0.00% | p50 0.00% | p25 0.00% | min 0.00%]
+    change:   [max 0 | p75 0 | median 0 | p25 0 | min 0]
+    change %: [max 0.00% | p75 0.00% | median 0.00% | p25 0.00% | min 0.00%]
 
   heap_increase:
     status:   No significant changes detected 👍
     counts:   [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
-    change:   [max 0 | p75 0 | p50 0 | p25 0 | min 0]
-    change %: [max 0.00% | p75 0.00% | p50 0.00% | p25 0.00% | min 0.00%]
+    change:   [max 0 | p75 0 | median 0 | p25 0 | min 0]
+    change %: [max 0.00% | p75 0.00% | median 0.00% | p25 0.00% | min 0.00%]
 
   stable_memory_increase:
     status:   No significant changes detected 👍
     counts:   [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
-    change:   [max 0 | p75 0 | p50 0 | p25 0 | min 0]
-    change %: [max 0.00% | p75 0.00% | p50 0.00% | p25 0.00% | min 0.00%]
+    change:   [max 0 | p75 0 | median 0 | p25 0 | min 0]
+    change %: [max 0.00% | p75 0.00% | median 0.00% | p25 0.00% | min 0.00%]
 
 ---------------------------------------------------

--- a/canbench-bin/tests/expected/benchmark_works_with_init_args.txt
+++ b/canbench-bin/tests/expected/benchmark_works_with_init_args.txt
@@ -12,19 +12,19 @@ Summary:
   instructions:
     status:   No significant changes detected 👍
     counts:   [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
-    change:   [min 0 | med 0 | max 0]
-    change %: [min 0.00% | med 0.00% | max 0.00%]
+    change:   [max 0 | p75 0 | p50 0 | p25 0 | min 0]
+    change %: [max 0.00% | p75 0.00% | p50 0.00% | p25 0.00% | min 0.00%]
 
   heap_increase:
     status:   No significant changes detected 👍
     counts:   [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
-    change:   [min 0 | med 0 | max 0]
-    change %: [min 0.00% | med 0.00% | max 0.00%]
+    change:   [max 0 | p75 0 | p50 0 | p25 0 | min 0]
+    change %: [max 0.00% | p75 0.00% | p50 0.00% | p25 0.00% | min 0.00%]
 
   stable_memory_increase:
     status:   No significant changes detected 👍
     counts:   [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
-    change:   [min 0 | med 0 | max 0]
-    change %: [min 0.00% | med 0.00% | max 0.00%]
+    change:   [max 0 | p75 0 | p50 0 | p25 0 | min 0]
+    change %: [max 0.00% | p75 0.00% | p50 0.00% | p25 0.00% | min 0.00%]
 
 ---------------------------------------------------

--- a/canbench-bin/tests/expected/reports_repeated_scope_in_existing_benchmark.txt
+++ b/canbench-bin/tests/expected/reports_repeated_scope_in_existing_benchmark.txt
@@ -17,20 +17,20 @@ Summary:
   instructions:
     status:   Regressions detected! 🔴
     counts:   [total 1 | new 0 | improved 0 | regressed 1 | unchanged 0]
-    change:   [min +16.50K | med +16.50K | max +16.50K]
-    change %: [min +inf% | med +inf% | max +inf%]
+    change:   [max +16.50K | p75 +16.50K | p50 +16.50K | p25 +16.50K | min +16.50K]
+    change %: [max +inf% | p75 +inf% | p50 +inf% | p25 +inf% | min +inf%]
 
   heap_increase:
     status:   No significant changes detected 👍
     counts:   [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
-    change:   [min 0 | med 0 | max 0]
-    change %: [min 0.00% | med 0.00% | max 0.00%]
+    change:   [max 0 | p75 0 | p50 0 | p25 0 | min 0]
+    change %: [max 0.00% | p75 0.00% | p50 0.00% | p25 0.00% | min 0.00%]
 
   stable_memory_increase:
     status:   No significant changes detected 👍
     counts:   [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
-    change:   [min 0 | med 0 | max 0]
-    change %: [min 0.00% | med 0.00% | max 0.00%]
+    change:   [max 0 | p75 0 | p50 0 | p25 0 | min 0]
+    change %: [max 0.00% | p75 0.00% | p50 0.00% | p25 0.00% | min 0.00%]
 
 ---------------------------------------------------
 

--- a/canbench-bin/tests/expected/reports_repeated_scope_in_existing_benchmark.txt
+++ b/canbench-bin/tests/expected/reports_repeated_scope_in_existing_benchmark.txt
@@ -17,20 +17,20 @@ Summary:
   instructions:
     status:   Regressions detected! 🔴
     counts:   [total 1 | new 0 | improved 0 | regressed 1 | unchanged 0]
-    change:   [max +16.50K | p75 +16.50K | p50 +16.50K | p25 +16.50K | min +16.50K]
-    change %: [max +inf% | p75 +inf% | p50 +inf% | p25 +inf% | min +inf%]
+    change:   [max +16.50K | p75 +16.50K | median +16.50K | p25 +16.50K | min +16.50K]
+    change %: [max +inf% | p75 +inf% | median +inf% | p25 +inf% | min +inf%]
 
   heap_increase:
     status:   No significant changes detected 👍
     counts:   [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
-    change:   [max 0 | p75 0 | p50 0 | p25 0 | min 0]
-    change %: [max 0.00% | p75 0.00% | p50 0.00% | p25 0.00% | min 0.00%]
+    change:   [max 0 | p75 0 | median 0 | p25 0 | min 0]
+    change %: [max 0.00% | p75 0.00% | median 0.00% | p25 0.00% | min 0.00%]
 
   stable_memory_increase:
     status:   No significant changes detected 👍
     counts:   [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
-    change:   [max 0 | p75 0 | p50 0 | p25 0 | min 0]
-    change %: [max 0.00% | p75 0.00% | p50 0.00% | p25 0.00% | min 0.00%]
+    change:   [max 0 | p75 0 | median 0 | p25 0 | min 0]
+    change %: [max 0.00% | p75 0.00% | median 0.00% | p25 0.00% | min 0.00%]
 
 ---------------------------------------------------
 

--- a/canbench-bin/tests/expected/reports_scopes_in_existing_benchmark.txt
+++ b/canbench-bin/tests/expected/reports_scopes_in_existing_benchmark.txt
@@ -22,20 +22,20 @@ Summary:
   instructions:
     status:   Regressions detected! 🔴
     counts:   [total 1 | new 0 | improved 0 | regressed 1 | unchanged 0]
-    change:   [max +4.13K | p75 +4.13K | p50 +4.13K | p25 +4.13K | min +4.13K]
-    change %: [max +inf% | p75 +inf% | p50 +inf% | p25 +inf% | min +inf%]
+    change:   [max +4.13K | p75 +4.13K | median +4.13K | p25 +4.13K | min +4.13K]
+    change %: [max +inf% | p75 +inf% | median +inf% | p25 +inf% | min +inf%]
 
   heap_increase:
     status:   No significant changes detected 👍
     counts:   [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
-    change:   [max 0 | p75 0 | p50 0 | p25 0 | min 0]
-    change %: [max 0.00% | p75 0.00% | p50 0.00% | p25 0.00% | min 0.00%]
+    change:   [max 0 | p75 0 | median 0 | p25 0 | min 0]
+    change %: [max 0.00% | p75 0.00% | median 0.00% | p25 0.00% | min 0.00%]
 
   stable_memory_increase:
     status:   No significant changes detected 👍
     counts:   [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
-    change:   [max 0 | p75 0 | p50 0 | p25 0 | min 0]
-    change %: [max 0.00% | p75 0.00% | p50 0.00% | p25 0.00% | min 0.00%]
+    change:   [max 0 | p75 0 | median 0 | p25 0 | min 0]
+    change %: [max 0.00% | p75 0.00% | median 0.00% | p25 0.00% | min 0.00%]
 
 ---------------------------------------------------
 

--- a/canbench-bin/tests/expected/reports_scopes_in_existing_benchmark.txt
+++ b/canbench-bin/tests/expected/reports_scopes_in_existing_benchmark.txt
@@ -22,20 +22,20 @@ Summary:
   instructions:
     status:   Regressions detected! 🔴
     counts:   [total 1 | new 0 | improved 0 | regressed 1 | unchanged 0]
-    change:   [min +4.13K | med +4.13K | max +4.13K]
-    change %: [min +inf% | med +inf% | max +inf%]
+    change:   [max +4.13K | p75 +4.13K | p50 +4.13K | p25 +4.13K | min +4.13K]
+    change %: [max +inf% | p75 +inf% | p50 +inf% | p25 +inf% | min +inf%]
 
   heap_increase:
     status:   No significant changes detected 👍
     counts:   [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
-    change:   [min 0 | med 0 | max 0]
-    change %: [min 0.00% | med 0.00% | max 0.00%]
+    change:   [max 0 | p75 0 | p50 0 | p25 0 | min 0]
+    change %: [max 0.00% | p75 0.00% | p50 0.00% | p25 0.00% | min 0.00%]
 
   stable_memory_increase:
     status:   No significant changes detected 👍
     counts:   [total 1 | new 0 | improved 0 | regressed 0 | unchanged 1]
-    change:   [min 0 | med 0 | max 0]
-    change %: [min 0.00% | med 0.00% | max 0.00%]
+    change:   [max 0 | p75 0 | p50 0 | p25 0 | min 0]
+    change %: [max 0.00% | p75 0.00% | p50 0.00% | p25 0.00% | min 0.00%]
 
 ---------------------------------------------------
 


### PR DESCRIPTION
This PR updates the summary output format from `min | med | max` to `max | p75 | median | p25 | min`.

The new layout gives a clearer picture of value distribution, as the interquartile range (`p75`–`p25`) is typically more representative than extreme `max`/`min` values, which may be outliers.
