### PR TITLE
ci: fix benchmark run script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,11 +46,23 @@ jobs:
         env:
           RUST_BACKTRACE: 1
 
-  benchmark-fibonacci-example:
+  benchmark:
     runs-on: ubuntu-latest
     needs: [build]
+    strategy:
+      matrix:
+        name:
+          - fibonacci-example
+          - btreemap-vs-hashmap-example
+        include:
+          - name: fibonacci-example
+            project_dir: ./examples/fibonacci
+          - name: btreemap-vs-hashmap-example
+            project_dir: ./examples/btreemap_vs_hashmap
+
     env:
-      PROJECT_DIR: examples/fibonacci
+      PROJECT_DIR: ${{ matrix.project_dir }}
+
     steps:
       - name: Checkout current PR
         uses: actions/checkout@v4
@@ -77,64 +89,17 @@ jobs:
 
       - name: Benchmark
         run: |
-          bash ./scripts/ci_run_benchmark.sh $PROJECT_DIR ${{ github.job }}
+          bash ./scripts/ci_run_benchmark.sh $PROJECT_DIR ${{ matrix.name }}
 
       - uses: actions/upload-artifact@v4
         with:
-          name: canbench_result_${{github.job}}
-          path: /tmp/canbench_result_${{ github.job }}
+          name: canbench_result_${{ matrix.name }}
+          path: /tmp/canbench_result_${{ matrix.name }}
 
       - uses: actions/upload-artifact@v4
         with:
-          name: canbench_results_${{github.job}}_csv
-          path: /tmp/canbench_results_${{ github.job }}.csv
-
-      - name: Pass or fail
-        run: |
-          bash ./scripts/ci_post_run_benchmark.sh
-
-  benchmark-btreemap-vs-hashmap-example:
-    runs-on: ubuntu-latest
-    needs: [build]
-    env:
-      PROJECT_DIR: examples/btreemap_vs_hashmap
-    steps:
-      - name: Checkout current PR
-        uses: actions/checkout@v4
-
-      - name: Checkout main branch
-        uses: actions/checkout@v4
-        with:
-          ref: main
-          path: _canbench_main_branch
-
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-1
-
-      - name: Install Rust
-        run: |
-          rustup update $RUST_VERSION --no-self-update
-          rustup default $RUST_VERSION
-          rustup target add wasm32-unknown-unknown
-
-      - name: Benchmark
-        run: |
-          bash ./scripts/ci_run_benchmark.sh $PROJECT_DIR ${{ github.job }}
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: canbench_result_${{github.job}}
-          path: /tmp/canbench_result_${{ github.job }}
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: canbench_results_${{github.job}}_csv
-          path: /tmp/canbench_results_${{ github.job }}.csv
+          name: canbench_results_${{ matrix.name }}_csv
+          path: /tmp/canbench_results_${{ matrix.name }}.csv
 
       - name: Pass or fail
         run: |
@@ -169,12 +134,9 @@ jobs:
     # Always run this job!
     if: always()
     needs:
-      [
-        build,
-        shell-checks,
-        benchmark-fibonacci-example,
-        benchmark-btreemap-vs-hashmap-example,
-      ]
+      - build
+      - shell-checks
+      - benchmark
     runs-on: ubuntu-latest
     steps:
       - name: check build result
@@ -185,10 +147,6 @@ jobs:
         if: ${{ needs.shell-checks.result != 'success' }}
         run: exit 1
 
-      - name: check benchmark-fibonacci-example result
-        if: ${{ needs.benchmark-fibonacci-example.result != 'success' }}
-        run: exit 1
-
-      - name: check benchmark-btreemap-vs-hashmap-example result
-        if: ${{ needs.benchmark-btreemap-vs-hashmap-example.result != 'success' }}
+      - name: check benchmark result
+        if: ${{ needs.benchmark.result != 'success' }}
         run: exit 1

--- a/scripts/ci_run_benchmark.sh
+++ b/scripts/ci_run_benchmark.sh
@@ -35,7 +35,7 @@ fi
 
 # Check if the canbench results file is up to date.
 pushd "$CANISTER_PATH"
-canbench --less-verbose --hide-results --show-summary --csv > $CANBENCH_OUTPUT
+canbench --less-verbose --hide-results --show-summary --csv > "$CANBENCH_OUTPUT"
 cp "./canbench_results.csv" "$CANBENCH_RESULTS_CSV_FILE"
 if grep -q "(regress\|(improved by \|(new)" "$CANBENCH_OUTPUT"; then
   UPDATED_MSG="**❌ \`$CANBENCH_RESULTS_FILE\` is not up to date**

--- a/scripts/ci_run_benchmark.sh
+++ b/scripts/ci_run_benchmark.sh
@@ -35,7 +35,8 @@ fi
 
 # Check if the canbench results file is up to date.
 pushd "$CANISTER_PATH"
-canbench --less-verbose > $CANBENCH_OUTPUT
+canbench --less-verbose --hide-results --show-summary --csv > $CANBENCH_OUTPUT
+cp "./canbench_results.csv" "$CANBENCH_RESULTS_CSV_FILE"
 if grep -q "(regress\|(improved by \|(new)" "$CANBENCH_OUTPUT"; then
   UPDATED_MSG="**❌ \`$CANBENCH_RESULTS_FILE\` is not up to date**
   If the performance change is expected, run \`canbench --persist [--csv]\` to update the benchmark results."
@@ -67,9 +68,9 @@ if [ -f "$MAIN_BRANCH_RESULTS_FILE" ]; then
   canbench --less-verbose --hide-results --show-summary --csv > "$CANBENCH_OUTPUT"
   cp "./canbench_results.csv" "$CANBENCH_RESULTS_CSV_FILE"
   popd
-
-  CSV_RESULTS_FILE_MSG="📦 \`canbench_results_$CANBENCH_JOB_NAME.csv\` available in [artifacts](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID})"
 fi
+
+CSV_RESULTS_FILE_MSG="📦 \`canbench_results_$CANBENCH_JOB_NAME.csv\` available in [artifacts](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID})"
 
 # Append the update status and benchmark output to the comment.
 {


### PR DESCRIPTION
This PR fixes benchmark run script to upload CSV report when no main reference is available.

It also simplifies CI yaml configuration to support matrix strategy for better multi-benchmarks support.