### PR TITLE
fix: fix recursive scope overcounting

### DIFF
--- a/canbench-bin/tests/expected/benchmark_reports_noisy_change_above_default_noise_threshold.txt
+++ b/canbench-bin/tests/expected/benchmark_reports_noisy_change_above_default_noise_threshold.txt
@@ -2,7 +2,7 @@
 
 Benchmark: noisy_change_above_default_threshold_test
   total:
-    instructions: 3.39 M (improved by 4.36%)
+    instructions: 3.39 M (improved by 4.35%)
     heap_increase: 62 pages (improved by 4.62%)
     stable_memory_increase: 100 pages (improved by 3.85%)
 
@@ -13,7 +13,7 @@ Summary:
     status:   Improvements detected! 🟢
     counts:   [total 1 | regressed 0 | improved 1 | new 0 | unchanged 0]
     change:   [max -154.17K | p75 -154.17K | median -154.17K | p25 -154.17K | min -154.17K]
-    change %: [max -4.36% | p75 -4.36% | median -4.36% | p25 -4.36% | min -4.36%]
+    change %: [max -4.35% | p75 -4.35% | median -4.35% | p25 -4.35% | min -4.35%]
 
   heap_increase:
     status:   Improvements detected! 🟢
@@ -32,7 +32,7 @@ Summary:
 Only significant changes:
 | status | name                                      | calls |   ins |  ins Δ% | HI |  HI Δ% | SMI |  SMI Δ% |
 |--------|-------------------------------------------|-------|-------|---------|----|--------|-----|---------|
-|   -    | noisy_change_above_default_threshold_test |       | 3.39M |  -4.36% | 62 | -4.62% | 100 |  -3.85% |
+|   -    | noisy_change_above_default_threshold_test |       | 3.39M |  -4.35% | 62 | -4.62% | 100 |  -3.85% |
 
 ins = instructions, HI = heap_increase, SMI = stable_memory_increase, Δ% = percent change
 

--- a/canbench-bin/tests/expected/benchmark_reports_noisy_change_within_custom_noise_threshold.txt
+++ b/canbench-bin/tests/expected/benchmark_reports_noisy_change_within_custom_noise_threshold.txt
@@ -2,7 +2,7 @@
 
 Benchmark: noisy_change_above_default_threshold_test
   total:
-    instructions: 3.39 M (-4.36%) (change within noise threshold)
+    instructions: 3.39 M (-4.35%) (change within noise threshold)
     heap_increase: 62 pages (-4.62%) (change within noise threshold)
     stable_memory_increase: 100 pages (-3.85%) (change within noise threshold)
 
@@ -13,7 +13,7 @@ Summary:
     status:   No significant changes detected 👍
     counts:   [total 1 | regressed 0 | improved 0 | new 0 | unchanged 1]
     change:   [max -154.17K | p75 -154.17K | median -154.17K | p25 -154.17K | min -154.17K]
-    change %: [max -4.36% | p75 -4.36% | median -4.36% | p25 -4.36% | min -4.36%]
+    change %: [max -4.35% | p75 -4.35% | median -4.35% | p25 -4.35% | min -4.35%]
 
   heap_increase:
     status:   No significant changes detected 👍

--- a/canbench-bin/tests/expected/reports_nested_scopes_benchmark.txt
+++ b/canbench-bin/tests/expected/reports_nested_scopes_benchmark.txt
@@ -1,46 +1,42 @@
 ---------------------------------------------------
 
-Benchmark: bench_nested_scopes (new)
+Benchmark: bench_nested_scopes
   total:
-    instructions: 12.64 K (new)
-    heap_increase: 0 pages (new)
-    stable_memory_increase: 0 pages (new)
+    instructions: 46.74 K (0.00%) (change within noise threshold)
+    heap_increase: 0 pages (no change)
+    stable_memory_increase: 0 pages (no change)
 
-  nested_scope (scope):
-    calls: 10 (new)
-    instructions: 11.56 K (new)
-    heap_increase: 0 pages (new)
-    stable_memory_increase: 0 pages (new)
+  nested_scope_1 (scope):
+    calls: 10 (no change)
+    instructions: 11.99 K (-0.03%) (change within noise threshold)
+    heap_increase: 0 pages (no change)
+    stable_memory_increase: 0 pages (no change)
+
+  nested_scope_2 (scope):
+    calls: 20 (no change)
+    instructions: 32.28 K (0.01%) (change within noise threshold)
+    heap_increase: 0 pages (no change)
+    stable_memory_increase: 0 pages (no change)
 
 ---------------------------------------------------
 
 Summary:
   instructions:
     status:   No significant changes detected 👍
-    counts:   [total 1 | regressed 0 | improved 0 | new 1 | unchanged 0]
-    change:   n/a
-    change %: n/a
+    counts:   [total 1 | regressed 0 | improved 0 | new 0 | unchanged 1]
+    change:   [max +2 | p75 +2 | median +2 | p25 +2 | min +2]
+    change %: [max 0.00% | p75 0.00% | median 0.00% | p25 0.00% | min 0.00%]
 
   heap_increase:
     status:   No significant changes detected 👍
-    counts:   [total 1 | regressed 0 | improved 0 | new 1 | unchanged 0]
-    change:   n/a
-    change %: n/a
+    counts:   [total 1 | regressed 0 | improved 0 | new 0 | unchanged 1]
+    change:   [max 0 | p75 0 | median 0 | p25 0 | min 0]
+    change %: [max 0.00% | p75 0.00% | median 0.00% | p25 0.00% | min 0.00%]
 
   stable_memory_increase:
     status:   No significant changes detected 👍
-    counts:   [total 1 | regressed 0 | improved 0 | new 1 | unchanged 0]
-    change:   n/a
-    change %: n/a
-
----------------------------------------------------
-
-Only significant changes:
-| status | name                              | calls |    ins |  ins Δ% | HI |  HI Δ% | SMI |  SMI Δ% |
-|--------|-----------------------------------|-------|--------|---------|----|--------|-----|---------|
-|  new   | bench_nested_scopes               |       | 12.64K |         |  0 |        |   0 |         |
-|  new   | bench_nested_scopes::nested_scope |    10 | 11.56K |         |  0 |        |   0 |         |
-
-ins = instructions, HI = heap_increase, SMI = stable_memory_increase, Δ% = percent change
+    counts:   [total 1 | regressed 0 | improved 0 | new 0 | unchanged 1]
+    change:   [max 0 | p75 0 | median 0 | p25 0 | min 0]
+    change %: [max 0.00% | p75 0.00% | median 0.00% | p25 0.00% | min 0.00%]
 
 ---------------------------------------------------

--- a/canbench-bin/tests/expected/reports_nested_scopes_benchmark.txt
+++ b/canbench-bin/tests/expected/reports_nested_scopes_benchmark.txt
@@ -1,14 +1,14 @@
 ---------------------------------------------------
 
-Benchmark: bench_repeated_scope_new (new)
+Benchmark: bench_nested_scopes (new)
   total:
-    instructions: 16.69 K (new)
+    instructions: 12.64 K (new)
     heap_increase: 0 pages (new)
     stable_memory_increase: 0 pages (new)
 
-  scope_1 (scope):
+  nested_scope (scope):
     calls: 10 (new)
-    instructions: 8214 (new)
+    instructions: 11.56 K (new)
     heap_increase: 0 pages (new)
     stable_memory_increase: 0 pages (new)
 
@@ -38,8 +38,8 @@ Summary:
 Only significant changes:
 | status | name                              | calls |    ins |  ins Δ% | HI |  HI Δ% | SMI |  SMI Δ% |
 |--------|-----------------------------------|-------|--------|---------|----|--------|-----|---------|
-|  new   | bench_repeated_scope_new          |       | 16.69K |         |  0 |        |   0 |         |
-|  new   | bench_repeated_scope_new::scope_1 |    10 |  8.21K |         |  0 |        |   0 |         |
+|  new   | bench_nested_scopes               |       | 12.64K |         |  0 |        |   0 |         |
+|  new   | bench_nested_scopes::nested_scope |    10 | 11.56K |         |  0 |        |   0 |         |
 
 ins = instructions, HI = heap_increase, SMI = stable_memory_increase, Δ% = percent change
 

--- a/canbench-bin/tests/expected/reports_nested_scopes_benchmark.txt
+++ b/canbench-bin/tests/expected/reports_nested_scopes_benchmark.txt
@@ -2,19 +2,19 @@
 
 Benchmark: bench_nested_scopes
   total:
-    instructions: 46.74 K (0.00%) (change within noise threshold)
+    instructions: 63.49 K (-0.01%) (change within noise threshold)
     heap_increase: 0 pages (no change)
     stable_memory_increase: 0 pages (no change)
 
   nested_scope_1 (scope):
     calls: 10 (no change)
-    instructions: 11.99 K (-0.03%) (change within noise threshold)
+    instructions: 17.14 K (-0.02%) (change within noise threshold)
     heap_increase: 0 pages (no change)
     stable_memory_increase: 0 pages (no change)
 
   nested_scope_2 (scope):
     calls: 20 (no change)
-    instructions: 32.28 K (0.01%) (change within noise threshold)
+    instructions: 42.58 K (0.01%) (change within noise threshold)
     heap_increase: 0 pages (no change)
     stable_memory_increase: 0 pages (no change)
 
@@ -24,8 +24,8 @@ Summary:
   instructions:
     status:   No significant changes detected 👍
     counts:   [total 1 | regressed 0 | improved 0 | new 0 | unchanged 1]
-    change:   [max +2 | p75 +2 | median +2 | p25 +2 | min +2]
-    change %: [max 0.00% | p75 0.00% | median 0.00% | p25 0.00% | min 0.00%]
+    change:   [max -4 | p75 -4 | median -4 | p25 -4 | min -4]
+    change %: [max -0.01% | p75 -0.01% | median -0.01% | p25 -0.01% | min -0.01%]
 
   heap_increase:
     status:   No significant changes detected 👍

--- a/canbench-bin/tests/expected/reports_nested_scopes_benchmark.txt
+++ b/canbench-bin/tests/expected/reports_nested_scopes_benchmark.txt
@@ -2,19 +2,19 @@
 
 Benchmark: bench_nested_scopes
   total:
-    instructions: 63.49 K (-0.01%) (change within noise threshold)
+    instructions: 30.09 M (-0.01%) (change within noise threshold)
     heap_increase: 0 pages (no change)
     stable_memory_increase: 0 pages (no change)
 
   nested_scope_1 (scope):
     calls: 10 (no change)
-    instructions: 17.14 K (-0.02%) (change within noise threshold)
+    instructions: 10.03 M (-0.04%) (change within noise threshold)
     heap_increase: 0 pages (no change)
     stable_memory_increase: 0 pages (no change)
 
   nested_scope_2 (scope):
     calls: 20 (no change)
-    instructions: 42.58 K (0.01%) (change within noise threshold)
+    instructions: 20.06 M (-0.00%) (change within noise threshold)
     heap_increase: 0 pages (no change)
     stable_memory_increase: 0 pages (no change)
 
@@ -24,7 +24,7 @@ Summary:
   instructions:
     status:   No significant changes detected 👍
     counts:   [total 1 | regressed 0 | improved 0 | new 0 | unchanged 1]
-    change:   [max -4 | p75 -4 | median -4 | p25 -4 | min -4]
+    change:   [max -1.92K | p75 -1.92K | median -1.92K | p25 -1.92K | min -1.92K]
     change %: [max -0.01% | p75 -0.01% | median -0.01% | p25 -0.01% | min -0.01%]
 
   heap_increase:

--- a/canbench-bin/tests/expected/reports_recursive_scopes_benchmark.txt
+++ b/canbench-bin/tests/expected/reports_recursive_scopes_benchmark.txt
@@ -1,20 +1,20 @@
 ---------------------------------------------------
 
-Benchmark: bench_nested_scopes
+Benchmark: bench_recursive_scopes
   total:
-    instructions: 30.09 M (-0.01%) (change within noise threshold)
+    instructions: 30.09 M (0.31%) (change within noise threshold)
     heap_increase: 0 pages (no change)
     stable_memory_increase: 0 pages (no change)
 
-  nested_scope_1 (scope):
+  recursive_scope_1 (scope):
     calls: 10 (no change)
-    instructions: 10.03 M (-0.04%) (change within noise threshold)
+    instructions: 10.03 M (0.26%) (change within noise threshold)
     heap_increase: 0 pages (no change)
     stable_memory_increase: 0 pages (no change)
 
-  nested_scope_2 (scope):
+  recursive_scope_2 (scope):
     calls: 20 (no change)
-    instructions: 20.06 M (-0.00%) (change within noise threshold)
+    instructions: 20.06 M (0.31%) (change within noise threshold)
     heap_increase: 0 pages (no change)
     stable_memory_increase: 0 pages (no change)
 
@@ -24,8 +24,8 @@ Summary:
   instructions:
     status:   No significant changes detected 👍
     counts:   [total 1 | regressed 0 | improved 0 | new 0 | unchanged 1]
-    change:   [max -1.92K | p75 -1.92K | median -1.92K | p25 -1.92K | min -1.92K]
-    change %: [max -0.01% | p75 -0.01% | median -0.01% | p25 -0.01% | min -0.01%]
+    change:   [max +91.83K | p75 +91.83K | median +91.83K | p25 +91.83K | min +91.83K]
+    change %: [max +0.31% | p75 +0.31% | median +0.31% | p25 +0.31% | min +0.31%]
 
   heap_increase:
     status:   No significant changes detected 👍

--- a/canbench-bin/tests/expected/reports_repeated_scope_in_existing_benchmark.txt
+++ b/canbench-bin/tests/expected/reports_repeated_scope_in_existing_benchmark.txt
@@ -2,13 +2,13 @@
 
 Benchmark: bench_repeated_scope_exists
   total:
-    instructions: 16.69 K (regressed from 0)
+    instructions: 16.46 K (regressed from 0)
     heap_increase: 0 pages (no change)
     stable_memory_increase: 0 pages (no change)
 
   scope_1 (scope):
     calls: 10 (no change)
-    instructions: 8214 (regressed by 926.75%)
+    instructions: 8734 (regressed by 991.75%)
     heap_increase: 0 pages (improved by 100.00%)
     stable_memory_increase: 0 pages (no change)
 
@@ -18,7 +18,7 @@ Summary:
   instructions:
     status:   Regressions detected! 🔴
     counts:   [total 1 | regressed 1 | improved 0 | new 0 | unchanged 0]
-    change:   [max +16.69K | p75 +16.69K | median +16.69K | p25 +16.69K | min +16.69K]
+    change:   [max +16.46K | p75 +16.46K | median +16.46K | p25 +16.46K | min +16.46K]
     change %: [max +inf% | p75 +inf% | median +inf% | p25 +inf% | min +inf%]
 
   heap_increase:
@@ -38,8 +38,8 @@ Summary:
 Only significant changes:
 | status | name                                 | calls |    ins |   ins Δ% | HI |    HI Δ% | SMI |  SMI Δ% |
 |--------|--------------------------------------|-------|--------|----------|----|----------|-----|---------|
-|   +    | bench_repeated_scope_exists          |       | 16.69K |    +inf% |  0 |    0.00% |   0 |   0.00% |
-|  +/-   | bench_repeated_scope_exists::scope_1 |    10 |  8.21K | +926.75% |  0 | -100.00% |   0 |   0.00% |
+|   +    | bench_repeated_scope_exists          |       | 16.46K |    +inf% |  0 |    0.00% |   0 |   0.00% |
+|  +/-   | bench_repeated_scope_exists::scope_1 |    10 |  8.73K | +991.75% |  0 | -100.00% |   0 |   0.00% |
 
 ins = instructions, HI = heap_increase, SMI = stable_memory_increase, Δ% = percent change
 

--- a/canbench-bin/tests/expected/reports_repeated_scope_in_existing_benchmark.txt
+++ b/canbench-bin/tests/expected/reports_repeated_scope_in_existing_benchmark.txt
@@ -2,13 +2,13 @@
 
 Benchmark: bench_repeated_scope_exists
   total:
-    instructions: 16.50 K (regressed from 0)
+    instructions: 16.69 K (regressed from 0)
     heap_increase: 0 pages (no change)
     stable_memory_increase: 0 pages (no change)
 
   scope_1 (scope):
     calls: 10 (no change)
-    instructions: 8124 (regressed by 915.50%)
+    instructions: 8214 (regressed by 926.75%)
     heap_increase: 0 pages (improved by 100.00%)
     stable_memory_increase: 0 pages (no change)
 
@@ -18,7 +18,7 @@ Summary:
   instructions:
     status:   Regressions detected! 🔴
     counts:   [total 1 | regressed 1 | improved 0 | new 0 | unchanged 0]
-    change:   [max +16.50K | p75 +16.50K | median +16.50K | p25 +16.50K | min +16.50K]
+    change:   [max +16.69K | p75 +16.69K | median +16.69K | p25 +16.69K | min +16.69K]
     change %: [max +inf% | p75 +inf% | median +inf% | p25 +inf% | min +inf%]
 
   heap_increase:
@@ -38,8 +38,8 @@ Summary:
 Only significant changes:
 | status | name                                 | calls |    ins |   ins Δ% | HI |    HI Δ% | SMI |  SMI Δ% |
 |--------|--------------------------------------|-------|--------|----------|----|----------|-----|---------|
-|   +    | bench_repeated_scope_exists          |       | 16.50K |    +inf% |  0 |    0.00% |   0 |   0.00% |
-|  +/-   | bench_repeated_scope_exists::scope_1 |    10 |  8.12K | +915.50% |  0 | -100.00% |   0 |   0.00% |
+|   +    | bench_repeated_scope_exists          |       | 16.69K |    +inf% |  0 |    0.00% |   0 |   0.00% |
+|  +/-   | bench_repeated_scope_exists::scope_1 |    10 |  8.21K | +926.75% |  0 | -100.00% |   0 |   0.00% |
 
 ins = instructions, HI = heap_increase, SMI = stable_memory_increase, Δ% = percent change
 

--- a/canbench-bin/tests/expected/reports_repeated_scope_in_new_benchmark.txt
+++ b/canbench-bin/tests/expected/reports_repeated_scope_in_new_benchmark.txt
@@ -2,13 +2,13 @@
 
 Benchmark: bench_repeated_scope_new (new)
   total:
-    instructions: 16.69 K (new)
+    instructions: 16.46 K (new)
     heap_increase: 0 pages (new)
     stable_memory_increase: 0 pages (new)
 
   scope_1 (scope):
     calls: 10 (new)
-    instructions: 8214 (new)
+    instructions: 8734 (new)
     heap_increase: 0 pages (new)
     stable_memory_increase: 0 pages (new)
 
@@ -38,8 +38,8 @@ Summary:
 Only significant changes:
 | status | name                              | calls |    ins |  ins Δ% | HI |  HI Δ% | SMI |  SMI Δ% |
 |--------|-----------------------------------|-------|--------|---------|----|--------|-----|---------|
-|  new   | bench_repeated_scope_new          |       | 16.69K |         |  0 |        |   0 |         |
-|  new   | bench_repeated_scope_new::scope_1 |    10 |  8.21K |         |  0 |        |   0 |         |
+|  new   | bench_repeated_scope_new          |       | 16.46K |         |  0 |        |   0 |         |
+|  new   | bench_repeated_scope_new::scope_1 |    10 |  8.73K |         |  0 |        |   0 |         |
 
 ins = instructions, HI = heap_increase, SMI = stable_memory_increase, Δ% = percent change
 

--- a/canbench-bin/tests/expected/reports_scopes_in_existing_benchmark.txt
+++ b/canbench-bin/tests/expected/reports_scopes_in_existing_benchmark.txt
@@ -2,19 +2,19 @@
 
 Benchmark: bench_scope_exists
   total:
-    instructions: 4180 (regressed from 0)
+    instructions: 4134 (regressed from 0)
     heap_increase: 0 pages (no change)
     stable_memory_increase: 0 pages (no change)
 
   scope_1 (scope):
     calls: 1 (no change)
-    instructions: 1059 (regressed by 32.38%)
+    instructions: 1111 (regressed by 38.88%)
     heap_increase: 0 pages (improved by 100.00%)
     stable_memory_increase: 0 pages (no change)
 
   scope_2 (scope):
     calls: 1 (new)
-    instructions: 795 (new)
+    instructions: 847 (new)
     heap_increase: 0 pages (new)
     stable_memory_increase: 0 pages (new)
 
@@ -24,7 +24,7 @@ Summary:
   instructions:
     status:   Regressions detected! 🔴
     counts:   [total 1 | regressed 1 | improved 0 | new 0 | unchanged 0]
-    change:   [max +4.18K | p75 +4.18K | median +4.18K | p25 +4.18K | min +4.18K]
+    change:   [max +4.13K | p75 +4.13K | median +4.13K | p25 +4.13K | min +4.13K]
     change %: [max +inf% | p75 +inf% | median +inf% | p25 +inf% | min +inf%]
 
   heap_increase:
@@ -44,9 +44,9 @@ Summary:
 Only significant changes:
 | status | name                        | calls |   ins |  ins Δ% | HI |    HI Δ% | SMI |  SMI Δ% |
 |--------|-----------------------------|-------|-------|---------|----|----------|-----|---------|
-|   +    | bench_scope_exists          |       | 4.18K |   +inf% |  0 |    0.00% |   0 |   0.00% |
-|  +/-   | bench_scope_exists::scope_1 |     1 | 1.06K | +32.38% |  0 | -100.00% |   0 |   0.00% |
-|  new   | bench_scope_exists::scope_2 |     1 |   795 |         |  0 |          |   0 |         |
+|   +    | bench_scope_exists          |       | 4.13K |   +inf% |  0 |    0.00% |   0 |   0.00% |
+|  +/-   | bench_scope_exists::scope_1 |     1 | 1.11K | +38.88% |  0 | -100.00% |   0 |   0.00% |
+|  new   | bench_scope_exists::scope_2 |     1 |   847 |         |  0 |          |   0 |         |
 
 ins = instructions, HI = heap_increase, SMI = stable_memory_increase, Δ% = percent change
 

--- a/canbench-bin/tests/expected/reports_scopes_in_existing_benchmark.txt
+++ b/canbench-bin/tests/expected/reports_scopes_in_existing_benchmark.txt
@@ -2,19 +2,19 @@
 
 Benchmark: bench_scope_exists
   total:
-    instructions: 4134 (regressed from 0)
+    instructions: 4180 (regressed from 0)
     heap_increase: 0 pages (no change)
     stable_memory_increase: 0 pages (no change)
 
   scope_1 (scope):
     calls: 1 (no change)
-    instructions: 1050 (regressed by 31.25%)
+    instructions: 1059 (regressed by 32.38%)
     heap_increase: 0 pages (improved by 100.00%)
     stable_memory_increase: 0 pages (no change)
 
   scope_2 (scope):
     calls: 1 (new)
-    instructions: 786 (new)
+    instructions: 795 (new)
     heap_increase: 0 pages (new)
     stable_memory_increase: 0 pages (new)
 
@@ -24,7 +24,7 @@ Summary:
   instructions:
     status:   Regressions detected! 🔴
     counts:   [total 1 | regressed 1 | improved 0 | new 0 | unchanged 0]
-    change:   [max +4.13K | p75 +4.13K | median +4.13K | p25 +4.13K | min +4.13K]
+    change:   [max +4.18K | p75 +4.18K | median +4.18K | p25 +4.18K | min +4.18K]
     change %: [max +inf% | p75 +inf% | median +inf% | p25 +inf% | min +inf%]
 
   heap_increase:
@@ -44,9 +44,9 @@ Summary:
 Only significant changes:
 | status | name                        | calls |   ins |  ins Δ% | HI |    HI Δ% | SMI |  SMI Δ% |
 |--------|-----------------------------|-------|-------|---------|----|----------|-----|---------|
-|   +    | bench_scope_exists          |       | 4.13K |   +inf% |  0 |    0.00% |   0 |   0.00% |
-|  +/-   | bench_scope_exists::scope_1 |     1 | 1.05K | +31.25% |  0 | -100.00% |   0 |   0.00% |
-|  new   | bench_scope_exists::scope_2 |     1 |   786 |         |  0 |          |   0 |         |
+|   +    | bench_scope_exists          |       | 4.18K |   +inf% |  0 |    0.00% |   0 |   0.00% |
+|  +/-   | bench_scope_exists::scope_1 |     1 | 1.06K | +32.38% |  0 | -100.00% |   0 |   0.00% |
+|  new   | bench_scope_exists::scope_2 |     1 |   795 |         |  0 |          |   0 |         |
 
 ins = instructions, HI = heap_increase, SMI = stable_memory_increase, Δ% = percent change
 

--- a/canbench-bin/tests/expected/reports_scopes_in_new_benchmark.txt
+++ b/canbench-bin/tests/expected/reports_scopes_in_new_benchmark.txt
@@ -2,19 +2,19 @@
 
 Benchmark: bench_scope_new (new)
   total:
-    instructions: 4180 (new)
+    instructions: 4134 (new)
     heap_increase: 0 pages (new)
     stable_memory_increase: 0 pages (new)
 
   scope_1 (scope):
     calls: 1 (new)
-    instructions: 1059 (new)
+    instructions: 1111 (new)
     heap_increase: 0 pages (new)
     stable_memory_increase: 0 pages (new)
 
   scope_2 (scope):
     calls: 1 (new)
-    instructions: 795 (new)
+    instructions: 847 (new)
     heap_increase: 0 pages (new)
     stable_memory_increase: 0 pages (new)
 
@@ -44,9 +44,9 @@ Summary:
 Only significant changes:
 | status | name                     | calls |   ins |  ins Δ% | HI |  HI Δ% | SMI |  SMI Δ% |
 |--------|--------------------------|-------|-------|---------|----|--------|-----|---------|
-|  new   | bench_scope_new          |       | 4.18K |         |  0 |        |   0 |         |
-|  new   | bench_scope_new::scope_1 |     1 | 1.06K |         |  0 |        |   0 |         |
-|  new   | bench_scope_new::scope_2 |     1 |   795 |         |  0 |        |   0 |         |
+|  new   | bench_scope_new          |       | 4.13K |         |  0 |        |   0 |         |
+|  new   | bench_scope_new::scope_1 |     1 | 1.11K |         |  0 |        |   0 |         |
+|  new   | bench_scope_new::scope_2 |     1 |   847 |         |  0 |        |   0 |         |
 
 ins = instructions, HI = heap_increase, SMI = stable_memory_increase, Δ% = percent change
 

--- a/canbench-bin/tests/expected/reports_scopes_in_new_benchmark.txt
+++ b/canbench-bin/tests/expected/reports_scopes_in_new_benchmark.txt
@@ -2,19 +2,19 @@
 
 Benchmark: bench_scope_new (new)
   total:
-    instructions: 4134 (new)
+    instructions: 4180 (new)
     heap_increase: 0 pages (new)
     stable_memory_increase: 0 pages (new)
 
   scope_1 (scope):
     calls: 1 (new)
-    instructions: 1050 (new)
+    instructions: 1059 (new)
     heap_increase: 0 pages (new)
     stable_memory_increase: 0 pages (new)
 
   scope_2 (scope):
     calls: 1 (new)
-    instructions: 786 (new)
+    instructions: 795 (new)
     heap_increase: 0 pages (new)
     stable_memory_increase: 0 pages (new)
 
@@ -44,9 +44,9 @@ Summary:
 Only significant changes:
 | status | name                     | calls |   ins |  ins Δ% | HI |  HI Δ% | SMI |  SMI Δ% |
 |--------|--------------------------|-------|-------|---------|----|--------|-----|---------|
-|  new   | bench_scope_new          |       | 4.13K |         |  0 |        |   0 |         |
-|  new   | bench_scope_new::scope_1 |     1 | 1.05K |         |  0 |        |   0 |         |
-|  new   | bench_scope_new::scope_2 |     1 |   786 |         |  0 |        |   0 |         |
+|  new   | bench_scope_new          |       | 4.18K |         |  0 |        |   0 |         |
+|  new   | bench_scope_new::scope_1 |     1 | 1.06K |         |  0 |        |   0 |         |
+|  new   | bench_scope_new::scope_2 |     1 |   795 |         |  0 |        |   0 |         |
 
 ins = instructions, HI = heap_increase, SMI = stable_memory_increase, Δ% = percent change
 

--- a/canbench-bin/tests/tests.rs
+++ b/canbench-bin/tests/tests.rs
@@ -373,10 +373,10 @@ fn reports_repeated_scope_in_existing_benchmark() {
 }
 
 #[test]
-fn reports_nested_scopes_benchmark() {
+fn reports_recursive_scopes_benchmark() {
     let name = current_test_name!();
     BenchTest::canister("measurements_output")
-        .with_bench("bench_nested_scopes")
+        .with_bench("bench_recursive_scopes")
         .run(|output| {
             let expected = load_expected(name, &output);
             assert_success!(output, expected.as_str());

--- a/canbench-bin/tests/tests.rs
+++ b/canbench-bin/tests/tests.rs
@@ -371,3 +371,14 @@ fn reports_repeated_scope_in_existing_benchmark() {
             assert_success!(output, expected.as_str());
         });
 }
+
+#[test]
+fn reports_nested_scopes_benchmark() {
+    let name = current_test_name!();
+    BenchTest::canister("measurements_output")
+        .with_bench("bench_nested_scopes")
+        .run(|output| {
+            let expected = load_expected(name, &output);
+            assert_success!(output, expected.as_str());
+        });
+}

--- a/canbench-rs/src/lib.rs
+++ b/canbench-rs/src/lib.rs
@@ -618,13 +618,13 @@ impl BenchScope {
 
 impl Drop for BenchScope {
     fn drop(&mut self) {
-        let start_instructions = self.start_instructions;
-        let instructions = instruction_count() - self.start_instructions;
-        let stable_memory_increase = ic_cdk::api::stable::stable_size() - self.start_stable_memory;
-        let heap_increase = heap_size() - self.start_heap;
-
         SCOPES.with(|p| {
             let mut p = p.borrow_mut();
+            let start_instructions = self.start_instructions;
+            let stable_memory_increase =
+                ic_cdk::api::stable::stable_size() - self.start_stable_memory;
+            let heap_increase = heap_size() - self.start_heap;
+            let instructions = instruction_count() - self.start_instructions;
             p.entry(self.name).or_default().push(Measurement {
                 start_instructions,
                 calls: 1,

--- a/tests/measurements_output/canbench_results.yml
+++ b/tests/measurements_output/canbench_results.yml
@@ -75,4 +75,23 @@ benches:
         calls: 10
         heap_increase: 12
         instructions: 800
+
+  # A benchmark that checks nested scopes.
+  bench_nested_scopes:
+    total:
+      calls: 1
+      heap_increase: 0
+      instructions: 46740
+      stable_memory_increase: 0
+
+    scopes:
+      nested_scope_1:
+        calls: 10
+        heap_increase: 0
+        instructions: 11990
+
+      nested_scope_2:
+        calls: 20
+        heap_increase: 0
+        instructions: 32280
 version: 0.1.15

--- a/tests/measurements_output/canbench_results.yml
+++ b/tests/measurements_output/canbench_results.yml
@@ -81,17 +81,17 @@ benches:
     total:
       calls: 1
       heap_increase: 0
-      instructions: 46740
+      instructions: 63490
       stable_memory_increase: 0
 
     scopes:
       nested_scope_1:
         calls: 10
         heap_increase: 0
-        instructions: 11990
+        instructions: 17140
 
       nested_scope_2:
         calls: 20
         heap_increase: 0
-        instructions: 32280
+        instructions: 42580
 version: 0.1.15

--- a/tests/measurements_output/canbench_results.yml
+++ b/tests/measurements_output/canbench_results.yml
@@ -62,6 +62,7 @@ benches:
         calls: 1
         heap_increase: 12
         instructions: 800
+
   # A benchmark that is expected to return an increase of new repeated scope steps.
   bench_repeated_scope_exists:
     total:
@@ -76,22 +77,22 @@ benches:
         heap_increase: 12
         instructions: 800
 
-  # A benchmark that checks nested scopes.
-  bench_nested_scopes:
+  # A benchmark with separate recursive scopes.
+  bench_recursive_scopes:
     total:
       calls: 1
       heap_increase: 0
-      instructions: 30090000
+      instructions: 30000000
       stable_memory_increase: 0
 
     scopes:
-      nested_scope_1:
+      recursive_scope_1:
         calls: 10
         heap_increase: 0
-        instructions: 10030000
+        instructions: 10000000
 
-      nested_scope_2:
+      recursive_scope_2:
         calls: 20
         heap_increase: 0
-        instructions: 20060000
+        instructions: 20000000
 version: 0.1.15

--- a/tests/measurements_output/canbench_results.yml
+++ b/tests/measurements_output/canbench_results.yml
@@ -81,17 +81,17 @@ benches:
     total:
       calls: 1
       heap_increase: 0
-      instructions: 63490
+      instructions: 30090000
       stable_memory_increase: 0
 
     scopes:
       nested_scope_1:
         calls: 10
         heap_increase: 0
-        instructions: 17140
+        instructions: 10030000
 
       nested_scope_2:
         calls: 20
         heap_increase: 0
-        instructions: 42580
+        instructions: 20060000
 version: 0.1.15

--- a/tests/measurements_output/src/main.rs
+++ b/tests/measurements_output/src/main.rs
@@ -121,12 +121,23 @@ fn bench_repeated_scope_exists() {
     }
 }
 
-fn foo(depth: usize, name: &'static str) {
-    println!("foo");
-    if depth > 0 {
-        let _p = bench_scope(name);
-        foo(depth - 1, name);
+fn wait(instructions: u64) {
+    let start = ic_cdk::api::performance_counter(0);
+    while ic_cdk::api::performance_counter(0) - start < instructions {
+        // Call `black_box` to prevent loop from being optimized out.
+        for _i in 0..100 {
+            std::hint::black_box(0);
+        }
     }
+}
+
+fn foo(depth: usize, name: &'static str) {
+    if depth == 0 {
+        return;
+    }
+    let _p = bench_scope(name);
+    wait(1_000_000);
+    foo(depth - 1, name);
 }
 
 #[bench]

--- a/tests/measurements_output/src/main.rs
+++ b/tests/measurements_output/src/main.rs
@@ -122,6 +122,7 @@ fn bench_repeated_scope_exists() {
 }
 
 fn foo(depth: usize, name: &'static str) {
+    println!("foo");
     if depth > 0 {
         let _p = bench_scope(name);
         foo(depth - 1, name);

--- a/tests/measurements_output/src/main.rs
+++ b/tests/measurements_output/src/main.rs
@@ -121,29 +121,34 @@ fn bench_repeated_scope_exists() {
     }
 }
 
-fn wait(instructions: u64) {
+/// Busy-waits until approximately `instructions` have been consumed.
+fn wait_for_instructions(instructions: u64) {
     let start = ic_cdk::api::performance_counter(0);
     while ic_cdk::api::performance_counter(0) - start < instructions {
-        // Call `black_box` to prevent loop from being optimized out.
-        for _i in 0..100 {
+        // Prevents loop from being optimized away.
+        for _ in 0..100 {
             std::hint::black_box(0);
         }
     }
 }
 
-fn foo(depth: usize, name: &'static str) {
+/// Recursively measures recursive scopes, delaying by `instructions_delay` at each level.
+fn measure_recursive_scope(scope_name: &'static str, depth: usize, instructions_delay: u64) {
     if depth == 0 {
         return;
     }
-    let _p = bench_scope(name);
-    wait(1_000_000);
-    foo(depth - 1, name);
+
+    let _scope = bench_scope(scope_name);
+    wait_for_instructions(instructions_delay);
+    measure_recursive_scope(scope_name, depth - 1, instructions_delay);
 }
 
 #[bench]
-fn bench_nested_scopes() {
-    foo(10, "nested_scope_1");
-    foo(20, "nested_scope_2");
+fn bench_recursive_scopes() {
+    const INSTRUCTIONS_PER_CALL: u64 = 1_000_000;
+
+    measure_recursive_scope("recursive_scope_1", 10, INSTRUCTIONS_PER_CALL); // 10M instructions
+    measure_recursive_scope("recursive_scope_2", 20, INSTRUCTIONS_PER_CALL); // 20M instructions
 }
 
 #[export_name = "canister_query __canbench__broken_benchmark"]

--- a/tests/measurements_output/src/main.rs
+++ b/tests/measurements_output/src/main.rs
@@ -121,16 +121,17 @@ fn bench_repeated_scope_exists() {
     }
 }
 
-fn foo(depth: usize) {
+fn foo(depth: usize, name: &'static str) {
     if depth > 0 {
-        let _p = bench_scope("nested_scope");
-        foo(depth - 1);
+        let _p = bench_scope(name);
+        foo(depth - 1, name);
     }
 }
 
 #[bench]
 fn bench_nested_scopes() {
-    foo(10);
+    foo(10, "nested_scope_1");
+    foo(20, "nested_scope_2");
 }
 
 #[export_name = "canister_query __canbench__broken_benchmark"]

--- a/tests/measurements_output/src/main.rs
+++ b/tests/measurements_output/src/main.rs
@@ -121,6 +121,18 @@ fn bench_repeated_scope_exists() {
     }
 }
 
+fn foo(depth: usize) {
+    if depth > 0 {
+        let _p = bench_scope("nested_scope");
+        foo(depth - 1);
+    }
+}
+
+#[bench]
+fn bench_nested_scopes() {
+    foo(10);
+}
+
 #[export_name = "canister_query __canbench__broken_benchmark"]
 fn broken_benchmark() {
     // This benchmark doesn't reply, and will therefore fail.


### PR DESCRIPTION
Fixes overcounting of instructions in recursive scopes

Previously, instruction counts were summed for each scope without accounting for overlaps, leading to inflated scope totals in recursive calls. This change ensures instruction usage is calculated accurately by avoiding double-counting.