### PR TITLE
fix: pin pocket-ic to an exact version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,4 @@ syn = "1.0"
 tempfile = "3.3.0"
 walrus = "0.23.3"
 wasmparser = "0.119.0"
-# `pocket-ic` should be pinned to an exact version so that the PocketIC server binary version
-# `POCKET_IC_SERVER_VERSION` defined in `canbench-bin/src/lib.rs` is compatible.
-pocket-ic = "=9.0.0"
 rustc-demangle = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,5 +30,7 @@ syn = "1.0"
 tempfile = "3.3.0"
 walrus = "0.23.3"
 wasmparser = "0.119.0"
-pocket-ic = "9.0.0"
+# `pocket-ic` should be pinned to an exact version so that the PocketIC server binary version
+# `POCKET_IC_SERVER_VERSION` defined in `canbench-bin/src/lib.rs` is compatible.
+pocket-ic = "=9.0.0"
 rustc-demangle = "0.1"

--- a/canbench-bin/Cargo.toml
+++ b/canbench-bin/Cargo.toml
@@ -24,7 +24,9 @@ inferno = { version = "0.11", default-features = false, features = [
     "multithreaded",
     "nameattr",
 ] }
-pocket-ic.workspace = true
+# `pocket-ic` should be pinned to an exact version so that the PocketIC server binary version
+# `POCKET_IC_SERVER_VERSION` defined in `canbench-bin/src/lib.rs` is compatible.
+pocket-ic = "=9.0.0"
 reqwest.workspace = true
 rustc-demangle.workspace = true
 semver.workspace = true


### PR DESCRIPTION
Running `cargo install canbench` produces a `canbench` binary running into the following error:
```
Downloading runtime (will be cached for future uses)...
Failed to validate PocketIC server binary: `Incompatible PocketIC server version: got pocket-ic-server 9.0.1; expected pocket-ic-server 9.0.2.`. Going to download PocketIC server 9.0.2 from https://github.com/dfinity/pocketic/releases/download/9.0.2/pocket-ic-x86_64-linux.gz to the local path /tmp/pocket-ic-server-9.0.2/pocket-ic. To avoid downloads during test execution, please specify the path to the (ungzipped and executable) PocketIC server 9.0.2 using the function `PocketIcBuilder::with_server_binary` or using the `POCKET_IC_BIN` environment variable.
```
This is because `canbench` specifies `pocket-ic = "9.0.0"` and there is a more recent `pocket-ic` version 9.0.1 available by now which is actually used by `cargo install canbench`. That other `pocket-ic` version requires a different PocketIC server binary version so `canbench` can't use the cached PocketIC server binary (and the PocketIC library produces a warning about downloading a matching PocketIC server binary in the background).

This PR fixes the issue by pinning `pocket-ic = "=9.0.0"`. (An alternative is to use `cargo install canbench --locked`, but users might not realize that so pinning `pocket-ic = "=9.0.0"` looks more reasonable.)