### PR TITLE
ci: fix up-to-date benchmark results check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 **/*~
 tests/**/*.svg
 examples/**/*.svg
+
+tmp/

--- a/canbench-bin/src/summary.rs
+++ b/canbench-bin/src/summary.rs
@@ -48,19 +48,19 @@ where
         }
     }
 
-    let total = new + improved + regressed + unchanged;
+    let total = regressed + improved + new + unchanged;
     debug_assert_eq!(total, processed_entries, "total count mismatch");
 
     println!("  {label}:");
-    let status = match (new > 0, improved > 0, regressed > 0) {
+    let status = match (regressed > 0, improved > 0, new > 0) {
         (false, false, false) => "No significant changes 👍",
-        (true, false, false) => "New benchmarks added ➕",
+        (true, false, false) => "Regressions detected 🔴",
         (false, true, false) => "Improvements detected 🟢",
-        (false, false, true) => "Regressions detected 🔴",
-        (true, true, false) => "New benchmarks and improvements ➕🟢",
-        (true, false, true) => "New benchmarks and regressions ➕🔴",
-        (false, true, true) => "Improvements and regressions 🟢🔴",
-        (true, true, true) => "New benchmarks, improvements, and regressions ➕🟢🔴",
+        (false, false, true) => "New benchmarks added ➕",
+        (true, true, false) => "Regressions and improvements 🔴🟢",
+        (true, false, true) => "Regressions and new benchmarks 🔴➕",
+        (false, true, true) => "Improvements and new benchmarks 🟢➕",
+        (true, true, true) => "Regressions, improvements, and new benchmarks 🔴🟢➕",
     };
     println!("    status:   {status}");
     println!(

--- a/canbench-bin/src/summary.rs
+++ b/canbench-bin/src/summary.rs
@@ -52,11 +52,15 @@ where
     debug_assert_eq!(total, processed_entries, "total count mismatch");
 
     println!("  {label}:");
-    let status = match (improved, regressed) {
-        (0, 0) => "No significant changes detected 👍",
-        (0, _) => "Regressions detected! 🔴",
-        (_, 0) => "Improvements detected! 🟢",
-        _ => "Both regressions and improvements detected! 🔴🟢",
+    let status = match (new > 0, improved > 0, regressed > 0) {
+        (false, false, false) => "No significant changes 👍",
+        (true, false, false) => "New benchmarks added ➕",
+        (false, true, false) => "Improvements detected 🟢",
+        (false, false, true) => "Regressions detected 🔴",
+        (true, true, false) => "New benchmarks and improvements ➕🟢",
+        (true, false, true) => "New benchmarks and regressions ➕🔴",
+        (false, true, true) => "Improvements and regressions 🟢🔴",
+        (true, true, true) => "New benchmarks, improvements, and regressions ➕🟢🔴",
     };
     println!("    status:   {status}");
     println!(

--- a/canbench-bin/tests/expected/benchmark_heap_increase.txt
+++ b/canbench-bin/tests/expected/benchmark_heap_increase.txt
@@ -10,19 +10,19 @@ Benchmark: increase_heap_increase (new)
 
 Summary:
   instructions:
-    status:   No significant changes detected 👍
+    status:   New benchmarks added ➕
     counts:   [total 1 | regressed 0 | improved 0 | new 1 | unchanged 0]
     change:   n/a
     change %: n/a
 
   heap_increase:
-    status:   No significant changes detected 👍
+    status:   New benchmarks added ➕
     counts:   [total 1 | regressed 0 | improved 0 | new 1 | unchanged 0]
     change:   n/a
     change %: n/a
 
   stable_memory_increase:
-    status:   No significant changes detected 👍
+    status:   New benchmarks added ➕
     counts:   [total 1 | regressed 0 | improved 0 | new 1 | unchanged 0]
     change:   n/a
     change %: n/a

--- a/canbench-bin/tests/expected/benchmark_instruction_tracing.txt
+++ b/canbench-bin/tests/expected/benchmark_instruction_tracing.txt
@@ -11,19 +11,19 @@ Instruction traces written to write_stable_memory.svg
 
 Summary:
   instructions:
-    status:   No significant changes detected 👍
+    status:   New benchmarks added ➕
     counts:   [total 1 | regressed 0 | improved 0 | new 1 | unchanged 0]
     change:   n/a
     change %: n/a
 
   heap_increase:
-    status:   No significant changes detected 👍
+    status:   New benchmarks added ➕
     counts:   [total 1 | regressed 0 | improved 0 | new 1 | unchanged 0]
     change:   n/a
     change %: n/a
 
   stable_memory_increase:
-    status:   No significant changes detected 👍
+    status:   New benchmarks added ➕
     counts:   [total 1 | regressed 0 | improved 0 | new 1 | unchanged 0]
     change:   n/a
     change %: n/a

--- a/canbench-bin/tests/expected/benchmark_reports_improvement.txt
+++ b/canbench-bin/tests/expected/benchmark_reports_improvement.txt
@@ -10,19 +10,19 @@ Benchmark: improvement_test
 
 Summary:
   instructions:
-    status:   Improvements detected! 🟢
+    status:   Improvements detected 🟢
     counts:   [total 1 | regressed 0 | improved 1 | new 0 | unchanged 0]
     change:   [max -2.89K | p75 -2.89K | median -2.89K | p25 -2.89K | min -2.89K]
     change %: [max -93.32% | p75 -93.32% | median -93.32% | p25 -93.32% | min -93.32%]
 
   heap_increase:
-    status:   No significant changes detected 👍
+    status:   No significant changes 👍
     counts:   [total 1 | regressed 0 | improved 0 | new 0 | unchanged 1]
     change:   [max 0 | p75 0 | median 0 | p25 0 | min 0]
     change %: [max 0.00% | p75 0.00% | median 0.00% | p25 0.00% | min 0.00%]
 
   stable_memory_increase:
-    status:   No significant changes detected 👍
+    status:   No significant changes 👍
     counts:   [total 1 | regressed 0 | improved 0 | new 0 | unchanged 1]
     change:   [max 0 | p75 0 | median 0 | p25 0 | min 0]
     change %: [max 0.00% | p75 0.00% | median 0.00% | p25 0.00% | min 0.00%]

--- a/canbench-bin/tests/expected/benchmark_reports_no_changes.txt
+++ b/canbench-bin/tests/expected/benchmark_reports_no_changes.txt
@@ -10,19 +10,19 @@ Benchmark: no_changes_test
 
 Summary:
   instructions:
-    status:   No significant changes detected 👍
+    status:   No significant changes 👍
     counts:   [total 1 | regressed 0 | improved 0 | new 0 | unchanged 1]
     change:   [max 0 | p75 0 | median 0 | p25 0 | min 0]
     change %: [max 0.00% | p75 0.00% | median 0.00% | p25 0.00% | min 0.00%]
 
   heap_increase:
-    status:   No significant changes detected 👍
+    status:   No significant changes 👍
     counts:   [total 1 | regressed 0 | improved 0 | new 0 | unchanged 1]
     change:   [max 0 | p75 0 | median 0 | p25 0 | min 0]
     change %: [max 0.00% | p75 0.00% | median 0.00% | p25 0.00% | min 0.00%]
 
   stable_memory_increase:
-    status:   No significant changes detected 👍
+    status:   No significant changes 👍
     counts:   [total 1 | regressed 0 | improved 0 | new 0 | unchanged 1]
     change:   [max 0 | p75 0 | median 0 | p25 0 | min 0]
     change %: [max 0.00% | p75 0.00% | median 0.00% | p25 0.00% | min 0.00%]

--- a/canbench-bin/tests/expected/benchmark_reports_no_changes_with_hide_results.txt
+++ b/canbench-bin/tests/expected/benchmark_reports_no_changes_with_hide_results.txt
@@ -2,19 +2,19 @@
 
 Summary:
   instructions:
-    status:   No significant changes detected 👍
+    status:   No significant changes 👍
     counts:   [total 1 | regressed 0 | improved 0 | new 0 | unchanged 1]
     change:   [max 0 | p75 0 | median 0 | p25 0 | min 0]
     change %: [max 0.00% | p75 0.00% | median 0.00% | p25 0.00% | min 0.00%]
 
   heap_increase:
-    status:   No significant changes detected 👍
+    status:   No significant changes 👍
     counts:   [total 1 | regressed 0 | improved 0 | new 0 | unchanged 1]
     change:   [max 0 | p75 0 | median 0 | p25 0 | min 0]
     change %: [max 0.00% | p75 0.00% | median 0.00% | p25 0.00% | min 0.00%]
 
   stable_memory_increase:
-    status:   No significant changes detected 👍
+    status:   No significant changes 👍
     counts:   [total 1 | regressed 0 | improved 0 | new 0 | unchanged 1]
     change:   [max 0 | p75 0 | median 0 | p25 0 | min 0]
     change %: [max 0.00% | p75 0.00% | median 0.00% | p25 0.00% | min 0.00%]

--- a/canbench-bin/tests/expected/benchmark_reports_noisy_change.txt
+++ b/canbench-bin/tests/expected/benchmark_reports_noisy_change.txt
@@ -10,19 +10,19 @@ Benchmark: noisy_change_test
 
 Summary:
   instructions:
-    status:   No significant changes detected 👍
+    status:   No significant changes 👍
     counts:   [total 1 | regressed 0 | improved 0 | new 0 | unchanged 1]
     change:   [max -3 | p75 -3 | median -3 | p25 -3 | min -3]
     change %: [max -1.43% | p75 -1.43% | median -1.43% | p25 -1.43% | min -1.43%]
 
   heap_increase:
-    status:   No significant changes detected 👍
+    status:   No significant changes 👍
     counts:   [total 1 | regressed 0 | improved 0 | new 0 | unchanged 1]
     change:   [max 0 | p75 0 | median 0 | p25 0 | min 0]
     change %: [max 0.00% | p75 0.00% | median 0.00% | p25 0.00% | min 0.00%]
 
   stable_memory_increase:
-    status:   No significant changes detected 👍
+    status:   No significant changes 👍
     counts:   [total 1 | regressed 0 | improved 0 | new 0 | unchanged 1]
     change:   [max 0 | p75 0 | median 0 | p25 0 | min 0]
     change %: [max 0.00% | p75 0.00% | median 0.00% | p25 0.00% | min 0.00%]

--- a/canbench-bin/tests/expected/benchmark_reports_noisy_change_above_default_noise_threshold.txt
+++ b/canbench-bin/tests/expected/benchmark_reports_noisy_change_above_default_noise_threshold.txt
@@ -10,19 +10,19 @@ Benchmark: noisy_change_above_default_threshold_test
 
 Summary:
   instructions:
-    status:   Improvements detected! 🟢
+    status:   Improvements detected 🟢
     counts:   [total 1 | regressed 0 | improved 1 | new 0 | unchanged 0]
     change:   [max -154.17K | p75 -154.17K | median -154.17K | p25 -154.17K | min -154.17K]
     change %: [max -4.35% | p75 -4.35% | median -4.35% | p25 -4.35% | min -4.35%]
 
   heap_increase:
-    status:   Improvements detected! 🟢
+    status:   Improvements detected 🟢
     counts:   [total 1 | regressed 0 | improved 1 | new 0 | unchanged 0]
     change:   [max -3 | p75 -3 | median -3 | p25 -3 | min -3]
     change %: [max -4.62% | p75 -4.62% | median -4.62% | p25 -4.62% | min -4.62%]
 
   stable_memory_increase:
-    status:   Improvements detected! 🟢
+    status:   Improvements detected 🟢
     counts:   [total 1 | regressed 0 | improved 1 | new 0 | unchanged 0]
     change:   [max -4 | p75 -4 | median -4 | p25 -4 | min -4]
     change %: [max -3.85% | p75 -3.85% | median -3.85% | p25 -3.85% | min -3.85%]

--- a/canbench-bin/tests/expected/benchmark_reports_noisy_change_within_custom_noise_threshold.txt
+++ b/canbench-bin/tests/expected/benchmark_reports_noisy_change_within_custom_noise_threshold.txt
@@ -10,19 +10,19 @@ Benchmark: noisy_change_above_default_threshold_test
 
 Summary:
   instructions:
-    status:   No significant changes detected 👍
+    status:   No significant changes 👍
     counts:   [total 1 | regressed 0 | improved 0 | new 0 | unchanged 1]
     change:   [max -154.17K | p75 -154.17K | median -154.17K | p25 -154.17K | min -154.17K]
     change %: [max -4.35% | p75 -4.35% | median -4.35% | p25 -4.35% | min -4.35%]
 
   heap_increase:
-    status:   No significant changes detected 👍
+    status:   No significant changes 👍
     counts:   [total 1 | regressed 0 | improved 0 | new 0 | unchanged 1]
     change:   [max -3 | p75 -3 | median -3 | p25 -3 | min -3]
     change %: [max -4.62% | p75 -4.62% | median -4.62% | p25 -4.62% | min -4.62%]
 
   stable_memory_increase:
-    status:   No significant changes detected 👍
+    status:   No significant changes 👍
     counts:   [total 1 | regressed 0 | improved 0 | new 0 | unchanged 1]
     change:   [max -4 | p75 -4 | median -4 | p25 -4 | min -4]
     change %: [max -3.85% | p75 -3.85% | median -3.85% | p25 -3.85% | min -3.85%]

--- a/canbench-bin/tests/expected/benchmark_reports_regression.txt
+++ b/canbench-bin/tests/expected/benchmark_reports_regression.txt
@@ -10,19 +10,19 @@ Benchmark: regression_test
 
 Summary:
   instructions:
-    status:   Regressions detected! 🔴
+    status:   Regressions detected 🔴
     counts:   [total 1 | regressed 1 | improved 0 | new 0 | unchanged 0]
     change:   [max +197 | p75 +197 | median +197 | p25 +197 | min +197]
     change %: [max +1970.00% | p75 +1970.00% | median +1970.00% | p25 +1970.00% | min +1970.00%]
 
   heap_increase:
-    status:   No significant changes detected 👍
+    status:   No significant changes 👍
     counts:   [total 1 | regressed 0 | improved 0 | new 0 | unchanged 1]
     change:   [max 0 | p75 0 | median 0 | p25 0 | min 0]
     change %: [max 0.00% | p75 0.00% | median 0.00% | p25 0.00% | min 0.00%]
 
   stable_memory_increase:
-    status:   No significant changes detected 👍
+    status:   No significant changes 👍
     counts:   [total 1 | regressed 0 | improved 0 | new 0 | unchanged 1]
     change:   [max 0 | p75 0 | median 0 | p25 0 | min 0]
     change %: [max 0.00% | p75 0.00% | median 0.00% | p25 0.00% | min 0.00%]

--- a/canbench-bin/tests/expected/benchmark_reports_regression_from_zero.txt
+++ b/canbench-bin/tests/expected/benchmark_reports_regression_from_zero.txt
@@ -10,19 +10,19 @@ Benchmark: stable_memory_increase_from_zero
 
 Summary:
   instructions:
-    status:   Regressions detected! 🔴
+    status:   Regressions detected 🔴
     counts:   [total 1 | regressed 1 | improved 0 | new 0 | unchanged 0]
     change:   [max +307 | p75 +307 | median +307 | p25 +307 | min +307]
     change %: [max +inf% | p75 +inf% | median +inf% | p25 +inf% | min +inf%]
 
   heap_increase:
-    status:   No significant changes detected 👍
+    status:   No significant changes 👍
     counts:   [total 1 | regressed 0 | improved 0 | new 0 | unchanged 1]
     change:   [max 0 | p75 0 | median 0 | p25 0 | min 0]
     change %: [max 0.00% | p75 0.00% | median 0.00% | p25 0.00% | min 0.00%]
 
   stable_memory_increase:
-    status:   Regressions detected! 🔴
+    status:   Regressions detected 🔴
     counts:   [total 1 | regressed 1 | improved 0 | new 0 | unchanged 0]
     change:   [max +123 | p75 +123 | median +123 | p25 +123 | min +123]
     change %: [max +inf% | p75 +inf% | median +inf% | p25 +inf% | min +inf%]

--- a/canbench-bin/tests/expected/benchmark_stable_memory_increase.txt
+++ b/canbench-bin/tests/expected/benchmark_stable_memory_increase.txt
@@ -10,19 +10,19 @@ Benchmark: stable_memory_only_increase (new)
 
 Summary:
   instructions:
-    status:   No significant changes detected 👍
+    status:   New benchmarks added ➕
     counts:   [total 1 | regressed 0 | improved 0 | new 1 | unchanged 0]
     change:   n/a
     change %: n/a
 
   heap_increase:
-    status:   No significant changes detected 👍
+    status:   New benchmarks added ➕
     counts:   [total 1 | regressed 0 | improved 0 | new 1 | unchanged 0]
     change:   n/a
     change %: n/a
 
   stable_memory_increase:
-    status:   No significant changes detected 👍
+    status:   New benchmarks added ➕
     counts:   [total 1 | regressed 0 | improved 0 | new 1 | unchanged 0]
     change:   n/a
     change %: n/a

--- a/canbench-bin/tests/expected/benchmark_stable_writes.txt
+++ b/canbench-bin/tests/expected/benchmark_stable_writes.txt
@@ -10,19 +10,19 @@ Benchmark: write_stable_memory (new)
 
 Summary:
   instructions:
-    status:   No significant changes detected 👍
+    status:   New benchmarks added ➕
     counts:   [total 1 | regressed 0 | improved 0 | new 1 | unchanged 0]
     change:   n/a
     change %: n/a
 
   heap_increase:
-    status:   No significant changes detected 👍
+    status:   New benchmarks added ➕
     counts:   [total 1 | regressed 0 | improved 0 | new 1 | unchanged 0]
     change:   n/a
     change %: n/a
 
   stable_memory_increase:
-    status:   No significant changes detected 👍
+    status:   New benchmarks added ➕
     counts:   [total 1 | regressed 0 | improved 0 | new 1 | unchanged 0]
     change:   n/a
     change %: n/a

--- a/canbench-bin/tests/expected/benchmark_works_with_init_args.txt
+++ b/canbench-bin/tests/expected/benchmark_works_with_init_args.txt
@@ -10,19 +10,19 @@ Benchmark: state_check
 
 Summary:
   instructions:
-    status:   No significant changes detected 👍
+    status:   No significant changes 👍
     counts:   [total 1 | regressed 0 | improved 0 | new 0 | unchanged 1]
     change:   [max 0 | p75 0 | median 0 | p25 0 | min 0]
     change %: [max 0.00% | p75 0.00% | median 0.00% | p25 0.00% | min 0.00%]
 
   heap_increase:
-    status:   No significant changes detected 👍
+    status:   No significant changes 👍
     counts:   [total 1 | regressed 0 | improved 0 | new 0 | unchanged 1]
     change:   [max 0 | p75 0 | median 0 | p25 0 | min 0]
     change %: [max 0.00% | p75 0.00% | median 0.00% | p25 0.00% | min 0.00%]
 
   stable_memory_increase:
-    status:   No significant changes detected 👍
+    status:   No significant changes 👍
     counts:   [total 1 | regressed 0 | improved 0 | new 0 | unchanged 1]
     change:   [max 0 | p75 0 | median 0 | p25 0 | min 0]
     change %: [max 0.00% | p75 0.00% | median 0.00% | p25 0.00% | min 0.00%]

--- a/canbench-bin/tests/expected/reports_recursive_scopes_benchmark.txt
+++ b/canbench-bin/tests/expected/reports_recursive_scopes_benchmark.txt
@@ -22,19 +22,19 @@ Benchmark: bench_recursive_scopes
 
 Summary:
   instructions:
-    status:   No significant changes detected 👍
+    status:   No significant changes 👍
     counts:   [total 1 | regressed 0 | improved 0 | new 0 | unchanged 1]
     change:   [max +91.83K | p75 +91.83K | median +91.83K | p25 +91.83K | min +91.83K]
     change %: [max +0.31% | p75 +0.31% | median +0.31% | p25 +0.31% | min +0.31%]
 
   heap_increase:
-    status:   No significant changes detected 👍
+    status:   No significant changes 👍
     counts:   [total 1 | regressed 0 | improved 0 | new 0 | unchanged 1]
     change:   [max 0 | p75 0 | median 0 | p25 0 | min 0]
     change %: [max 0.00% | p75 0.00% | median 0.00% | p25 0.00% | min 0.00%]
 
   stable_memory_increase:
-    status:   No significant changes detected 👍
+    status:   No significant changes 👍
     counts:   [total 1 | regressed 0 | improved 0 | new 0 | unchanged 1]
     change:   [max 0 | p75 0 | median 0 | p25 0 | min 0]
     change %: [max 0.00% | p75 0.00% | median 0.00% | p25 0.00% | min 0.00%]

--- a/canbench-bin/tests/expected/reports_repeated_scope_in_existing_benchmark.txt
+++ b/canbench-bin/tests/expected/reports_repeated_scope_in_existing_benchmark.txt
@@ -16,19 +16,19 @@ Benchmark: bench_repeated_scope_exists
 
 Summary:
   instructions:
-    status:   Regressions detected! 🔴
+    status:   Regressions detected 🔴
     counts:   [total 1 | regressed 1 | improved 0 | new 0 | unchanged 0]
     change:   [max +16.46K | p75 +16.46K | median +16.46K | p25 +16.46K | min +16.46K]
     change %: [max +inf% | p75 +inf% | median +inf% | p25 +inf% | min +inf%]
 
   heap_increase:
-    status:   No significant changes detected 👍
+    status:   No significant changes 👍
     counts:   [total 1 | regressed 0 | improved 0 | new 0 | unchanged 1]
     change:   [max 0 | p75 0 | median 0 | p25 0 | min 0]
     change %: [max 0.00% | p75 0.00% | median 0.00% | p25 0.00% | min 0.00%]
 
   stable_memory_increase:
-    status:   No significant changes detected 👍
+    status:   No significant changes 👍
     counts:   [total 1 | regressed 0 | improved 0 | new 0 | unchanged 1]
     change:   [max 0 | p75 0 | median 0 | p25 0 | min 0]
     change %: [max 0.00% | p75 0.00% | median 0.00% | p25 0.00% | min 0.00%]

--- a/canbench-bin/tests/expected/reports_repeated_scope_in_new_benchmark.txt
+++ b/canbench-bin/tests/expected/reports_repeated_scope_in_new_benchmark.txt
@@ -16,19 +16,19 @@ Benchmark: bench_repeated_scope_new (new)
 
 Summary:
   instructions:
-    status:   No significant changes detected 👍
+    status:   New benchmarks added ➕
     counts:   [total 1 | regressed 0 | improved 0 | new 1 | unchanged 0]
     change:   n/a
     change %: n/a
 
   heap_increase:
-    status:   No significant changes detected 👍
+    status:   New benchmarks added ➕
     counts:   [total 1 | regressed 0 | improved 0 | new 1 | unchanged 0]
     change:   n/a
     change %: n/a
 
   stable_memory_increase:
-    status:   No significant changes detected 👍
+    status:   New benchmarks added ➕
     counts:   [total 1 | regressed 0 | improved 0 | new 1 | unchanged 0]
     change:   n/a
     change %: n/a

--- a/canbench-bin/tests/expected/reports_scopes_in_existing_benchmark.txt
+++ b/canbench-bin/tests/expected/reports_scopes_in_existing_benchmark.txt
@@ -22,19 +22,19 @@ Benchmark: bench_scope_exists
 
 Summary:
   instructions:
-    status:   Regressions detected! 🔴
+    status:   Regressions detected 🔴
     counts:   [total 1 | regressed 1 | improved 0 | new 0 | unchanged 0]
     change:   [max +4.13K | p75 +4.13K | median +4.13K | p25 +4.13K | min +4.13K]
     change %: [max +inf% | p75 +inf% | median +inf% | p25 +inf% | min +inf%]
 
   heap_increase:
-    status:   No significant changes detected 👍
+    status:   No significant changes 👍
     counts:   [total 1 | regressed 0 | improved 0 | new 0 | unchanged 1]
     change:   [max 0 | p75 0 | median 0 | p25 0 | min 0]
     change %: [max 0.00% | p75 0.00% | median 0.00% | p25 0.00% | min 0.00%]
 
   stable_memory_increase:
-    status:   No significant changes detected 👍
+    status:   No significant changes 👍
     counts:   [total 1 | regressed 0 | improved 0 | new 0 | unchanged 1]
     change:   [max 0 | p75 0 | median 0 | p25 0 | min 0]
     change %: [max 0.00% | p75 0.00% | median 0.00% | p25 0.00% | min 0.00%]

--- a/canbench-bin/tests/expected/reports_scopes_in_new_benchmark.txt
+++ b/canbench-bin/tests/expected/reports_scopes_in_new_benchmark.txt
@@ -22,19 +22,19 @@ Benchmark: bench_scope_new (new)
 
 Summary:
   instructions:
-    status:   No significant changes detected 👍
+    status:   New benchmarks added ➕
     counts:   [total 1 | regressed 0 | improved 0 | new 1 | unchanged 0]
     change:   n/a
     change %: n/a
 
   heap_increase:
-    status:   No significant changes detected 👍
+    status:   New benchmarks added ➕
     counts:   [total 1 | regressed 0 | improved 0 | new 1 | unchanged 0]
     change:   n/a
     change %: n/a
 
   stable_memory_increase:
-    status:   No significant changes detected 👍
+    status:   New benchmarks added ➕
     counts:   [total 1 | regressed 0 | improved 0 | new 1 | unchanged 0]
     change:   n/a
     change %: n/a

--- a/canbench-bin/tests/expected/supports_gzipped_wasm.txt
+++ b/canbench-bin/tests/expected/supports_gzipped_wasm.txt
@@ -18,19 +18,19 @@ Benchmark: bench_2 (new)
 
 Summary:
   instructions:
-    status:   No significant changes detected 👍
+    status:   New benchmarks added ➕
     counts:   [total 2 | regressed 0 | improved 0 | new 2 | unchanged 0]
     change:   n/a
     change %: n/a
 
   heap_increase:
-    status:   No significant changes detected 👍
+    status:   New benchmarks added ➕
     counts:   [total 2 | regressed 0 | improved 0 | new 2 | unchanged 0]
     change:   n/a
     change %: n/a
 
   stable_memory_increase:
-    status:   No significant changes detected 👍
+    status:   New benchmarks added ➕
     counts:   [total 2 | regressed 0 | improved 0 | new 2 | unchanged 0]
     change:   n/a
     change %: n/a

--- a/examples/fibonacci/canbench_results.yml
+++ b/examples/fibonacci/canbench_results.yml
@@ -3,7 +3,7 @@ benches:
     total:
       start_instructions: 17967
       calls: 1
-      instructions: 732
+      instructions: 732000
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}

--- a/examples/fibonacci/canbench_results.yml
+++ b/examples/fibonacci/canbench_results.yml
@@ -3,7 +3,7 @@ benches:
     total:
       start_instructions: 17967
       calls: 1
-      instructions: 732000
+      instructions: 732
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}

--- a/scripts/ci_run_benchmark.sh
+++ b/scripts/ci_run_benchmark.sh
@@ -63,9 +63,11 @@ cp "./canbench_results.csv" "$CANBENCH_RESULTS_CSV_FILE"
 if has_updates; then
   UPDATED_MSG="**❌ \`$CANBENCH_RESULTS_FILE\` is not up to date**
 If the performance change is expected, run \`canbench --persist [--csv]\` to update the benchmark results."
+  # Results are outdated; fail the job.
   echo "EXIT_STATUS=1" >> "$GITHUB_ENV"
 else
   UPDATED_MSG="✅ \`$CANBENCH_RESULTS_FILE\` is up to date"
+  # Results are up to date; job succeeds.
   echo "EXIT_STATUS=0" >> "$GITHUB_ENV"
 fi
 popd

--- a/scripts/ci_run_benchmark.sh
+++ b/scripts/ci_run_benchmark.sh
@@ -62,7 +62,7 @@ canbench --less-verbose --hide-results --show-summary --csv > "$CANBENCH_OUTPUT"
 cp "./canbench_results.csv" "$CANBENCH_RESULTS_CSV_FILE"
 if has_updates; then
   UPDATED_MSG="**❌ \`$CANBENCH_RESULTS_FILE\` is not up to date**
-If the performance change is expected, run \`canbench --persist [--csv]\` to update the benchmark results."
+  If the performance change is expected, run \`canbench --persist [--csv]\` to update the benchmark results."
   # Results are outdated; fail the job.
   echo "EXIT_STATUS=1" >> "$GITHUB_ENV"
 else

--- a/scripts/ci_run_benchmark.sh
+++ b/scripts/ci_run_benchmark.sh
@@ -33,21 +33,39 @@ if [ ! -f "$CANBENCH_RESULTS_FILE" ]; then
     exit 1
 fi
 
+# Function that checks if the benchmark output contains any updates
+has_updates() {
+  # Triggers for streamed results (old format)
+  local streamed_patterns=(
+    "\(regressed by"
+    "\(improved by"
+    "\(new\)"
+  )
+
+  # Triggers for summary status (new format)
+  local summary_patterns=(
+    "status:[[:space:]]+Regressions"
+    "status:[[:space:]]+Improvements"
+    "status:[[:space:]]+New[[:space:]]+benchmarks"
+  )
+
+  # Combine all patterns into a single extended regex
+  local all_patterns
+  all_patterns=$(IFS='|'; echo "${streamed_patterns[*]}|${summary_patterns[*]}")
+
+  grep -qE "$all_patterns" "$CANBENCH_OUTPUT"
+}
+
 # Check if the canbench results file is up to date.
 pushd "$CANISTER_PATH"
-# (!) Do not use `--hide-results` here, as it breaks the up-to-date check.
-canbench --less-verbose --show-summary --csv > "$CANBENCH_OUTPUT"
+canbench --less-verbose --hide-results --show-summary --csv > "$CANBENCH_OUTPUT"
 cp "./canbench_results.csv" "$CANBENCH_RESULTS_CSV_FILE"
-if grep -q "(regress\|(improved by \|(new)" "$CANBENCH_OUTPUT"; then
+if has_updates; then
   UPDATED_MSG="**❌ \`$CANBENCH_RESULTS_FILE\` is not up to date**
-  If the performance change is expected, run \`canbench --persist [--csv]\` to update the benchmark results."
-
-  # Results are outdated; fail the job.
+If the performance change is expected, run \`canbench --persist [--csv]\` to update the benchmark results."
   echo "EXIT_STATUS=1" >> "$GITHUB_ENV"
 else
-  UPDATED_MSG="✅ \`$CANBENCH_RESULTS_FILE\` is up to date";
-
-  # Results are up to date; job succeeds.
+  UPDATED_MSG="✅ \`$CANBENCH_RESULTS_FILE\` is up to date"
   echo "EXIT_STATUS=0" >> "$GITHUB_ENV"
 fi
 popd


### PR DESCRIPTION
This PR refines benchmark summary statuses and fixes canbench results up-to-date check.

Changes:
- the summary reflects newly added benchmarks
- up-to-date script can detect changes not only from streaming results, but also from summary status