### PR TITLE
ci: upload persisted canbench_results.yml file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,8 @@ jobs:
 
       - name: Install Rust
         run: |
-          rustup update $RUST_VERSION --no-self-update
-          rustup default $RUST_VERSION
+          rustup update ${RUST_VERSION} --no-self-update
+          rustup default ${RUST_VERSION}
           rustup component add rustfmt
           rustup component add clippy
 
@@ -85,8 +85,8 @@ jobs:
 
       - name: Install Rust
         run: |
-          rustup update $RUST_VERSION --no-self-update
-          rustup default $RUST_VERSION
+          rustup update ${RUST_VERSION} --no-self-update
+          rustup default ${RUST_VERSION}
           rustup target add wasm32-unknown-unknown
 
       - name: Benchmark
@@ -97,6 +97,11 @@ jobs:
         with:
           name: canbench_result_${{ matrix.name }}
           path: /tmp/canbench_result_${{ matrix.name }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: canbench_results_persisted_${{ matrix.name }}_yml
+          path: /tmp/canbench_results_persisted_${{ matrix.name }}.yml
 
       - uses: actions/upload-artifact@v4
         with:

--- a/scripts/ci_run_benchmark.sh
+++ b/scripts/ci_run_benchmark.sh
@@ -19,6 +19,7 @@ BASELINE_BRANCH_DIR=_canbench_baseline_branch
 CANBENCH_OUTPUT=/tmp/canbench_output.txt
 
 CANBENCH_RESULTS_FILE="$CANISTER_PATH/canbench_results.yml"
+CANBENCH_RESULTS_PERSISTED_FILE="/tmp/canbench_results_persisted_${CANBENCH_JOB_NAME}.yml"
 BASELINE_BRANCH_RESULTS_FILE="$BASELINE_BRANCH_DIR/$CANBENCH_RESULTS_FILE"
 
 CANBENCH_RESULTS_CSV_FILE="/tmp/canbench_results_${CANBENCH_JOB_NAME}.csv"
@@ -58,7 +59,8 @@ has_updates() {
 
 # Check if the canbench results file is up to date.
 pushd "$CANISTER_PATH"
-canbench --less-verbose --hide-results --show-summary --csv > "$CANBENCH_OUTPUT"
+canbench --less-verbose --hide-results --show-summary --csv --persist > "$CANBENCH_OUTPUT"
+cp "./canbench_results.yml" "$CANBENCH_RESULTS_PERSISTED_FILE"
 cp "./canbench_results.csv" "$CANBENCH_RESULTS_CSV_FILE"
 if has_updates; then
   UPDATED_MSG="**❌ \`$CANBENCH_RESULTS_FILE\` is not up to date**


### PR DESCRIPTION
This PR uploads persisted `canbench_results.yml` files as CI artifacts.