### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/canbench-post-comment.yml
+++ b/.github/workflows/canbench-post-comment.yml
@@ -13,7 +13,7 @@ jobs:
       matrix: ${{ steps.set-benchmarks.outputs.matrix }}
       pr_number: ${{ steps.set-benchmarks.outputs.pr_number }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - uses: dawidd6/action-download-artifact@09f2f74827fd3a8607589e5ad7f9398816f540fe
         with:
@@ -29,7 +29,7 @@ jobs:
       matrix: ${{fromJSON(needs.download-results.outputs.matrix)}}
     steps:
       - name: Post comment
-        uses: thollander/actions-comment-pull-request@v2
+        uses: thollander/actions-comment-pull-request@fabd468d3a1a0b97feee5f6b9e499eab0dd903f6 # v2.5.0
         with:
           message: |
             ${{ matrix.benchmark.result }}

--- a/.github/workflows/ci-notify-slack.yml
+++ b/.github/workflows/ci-notify-slack.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Sanitize PR title
         id: sanitize

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
 
       - name: Cache Cargo
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: |
             ~/.cargo/registry
@@ -67,15 +67,15 @@ jobs:
 
     steps:
       - name: Checkout current PR
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Checkout baseline branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: main
           path: _canbench_baseline_branch
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
         with:
           path: |
             ~/.cargo/registry
@@ -93,17 +93,17 @@ jobs:
         run: |
           bash ./scripts/ci_run_benchmark.sh $PROJECT_DIR ${{ matrix.name }}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: canbench_result_${{ matrix.name }}
           path: /tmp/canbench_result_${{ matrix.name }}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: canbench_results_persisted_${{ matrix.name }}_yml
           path: /tmp/canbench_results_persisted_${{ matrix.name }}.yml
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: canbench_results_${{ matrix.name }}_csv
           path: /tmp/canbench_results_${{ matrix.name }}.csv
@@ -116,9 +116,9 @@ jobs:
     name: ShellCheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Run ShellCheck
-        uses: ludeeus/action-shellcheck@master
+        uses: ludeeus/action-shellcheck@00b27aa7cb85167568cb48a3838b75f4265f2bca # master
         env:
           SHELLCHECK_OPTS: -e SC1090 -e SC2119 -e SC1091
 
@@ -126,13 +126,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Save PR number
         run: |
           echo ${{ github.event.number }} > /tmp/pr_number
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: pr_number
           path: /tmp/pr_number

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,9 +16,9 @@ jobs:
       id-token: write # Required for OIDC token exchange
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
-      - uses: rust-lang/crates-io-auth-action@v1
+      - uses: rust-lang/crates-io-auth-action@b7e9a28eded4986ec6b1fa40eeee8f8f165559ec # v1
         id: auth
 
       - run: echo "Preparing to cargo publish ${{ github.ref_name }}."


### PR DESCRIPTION
## Pin GitHub Actions to commit SHAs

GitHub Actions referenced by tag (e.g. `actions/checkout@v4`) use a mutable pointer — the tag owner can move it to a different commit at any time, including a malicious one. This is the attack vector used in the tj-actions/changed-files incident (CVE-2025-30066).

Pinning to a full 40-character commit SHA makes the reference immutable. The `# tag` comment preserves human readability so reviewers can tell which version is pinned.

Important: a SHA can also originate from a forked repository. A malicious actor can fork an action, push a compromised commit to the fork, and the SHA will resolve — but it won't exist in the upstream canonical repo. Each SHA in this PR was verified against the action's canonical repository (not a fork).

### Changes

- `actions/checkout@v4` -> `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1`
  - Version: v4.3.1 | Latest: v6.0.2 | Release age: 88d
  - Commit: https://github.com/actions/checkout/commit/34e114876b0b11c390a56381ad16ebd13914f8d5

- `thollander/actions-comment-pull-request@v2` -> `thollander/actions-comment-pull-request@fabd468d3a1a0b97feee5f6b9e499eab0dd903f6 # v2.5.0`
  - Version: v2.5.0 | Latest: v3.0.1 | Release age: 522d
  - Commit: https://github.com/thollander/actions-comment-pull-request/commit/fabd468d3a1a0b97feee5f6b9e499eab0dd903f6

- `actions/checkout@v2` -> `actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0`
  - Version: v2.7.0 | Latest: v6.0.2 | Release age: 88d
  - Commit: https://github.com/actions/checkout/commit/ee0669bd1cc54295c223e0bb666b733df41de1c5

- `actions/cache@v4` -> `actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0`
  - Version: v4.3.0 | Latest: v5.0.4 | Release age: 21d
  - Commit: https://github.com/actions/cache/commit/0057852bfaa89a56745cba8c7296529d2fc39830

- `actions/cache@v3` -> `actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0`
  - Version: v3.5.0 | Latest: v5.0.4 | Release age: 21d
  - Commit: https://github.com/actions/cache/commit/6f8efc29b200d32929f49075959781ed54ec270c

- `actions/upload-artifact@v4` -> `actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2`
  - Version: v4.6.2 | Latest: v3.2.2 | Release age: 22d
  - Commit: https://github.com/actions/upload-artifact/commit/ea165f8d65b6e75b540449e92b4886f43607fa02

- `ludeeus/action-shellcheck@master` -> `ludeeus/action-shellcheck@00b27aa7cb85167568cb48a3838b75f4265f2bca # master`
  - Version: master | Latest: 2.0.0 | Release age: 1164d
  - Commit: https://github.com/ludeeus/action-shellcheck/commit/00b27aa7cb85167568cb48a3838b75f4265f2bca

- `actions/checkout@v5` -> `actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1`
  - Version: v5.0.1 | Latest: v6.0.2 | Release age: 88d
  - Commit: https://github.com/actions/checkout/commit/93cb6efe18208431cddfb8368fd83d5badbf9bfd

- `rust-lang/crates-io-auth-action@v1` -> `rust-lang/crates-io-auth-action@b7e9a28eded4986ec6b1fa40eeee8f8f165559ec # v1`
  - Version: v1 | Latest: v1.0.4 | Release age: 16d
  - Commit: https://github.com/rust-lang/crates-io-auth-action/commit/b7e9a28eded4986ec6b1fa40eeee8f8f165559ec


### Files modified

- `.github/workflows/canbench-post-comment.yml`
- `.github/workflows/ci-notify-slack.yml`
- `.github/workflows/ci.yml`
- `.github/workflows/publish.yml`